### PR TITLE
lab6_Audit.adoc: remove the explicit SSH commands

### DIFF
--- a/RHELSecurityLabSummit/documentation/lab6_Audit.adoc
+++ b/RHELSecurityLabSummit/documentation/lab6_Audit.adoc
@@ -7,6 +7,33 @@ Enterprise Linux.  The exercises below are intended as part of a Red Hat Summit
 lab session using RHEL-7.5, and may require modification to work in other lab
 environments.
 
+== Accessing the Audit Lab System
+
+All of the exercises in this lab are run on the _audit.example.com_ host,
+either as the "root" or "auditlab" user.  Each set of exercises instructs you
+about which user to use, and the username is reflected in the command prompt,
+as seen in the examples below:
+
+* The "root" user prompt on _audit.example.com_
+
+	[root@audit ~]#
+
+* The "auditlab" user prompt on _audit.example.com_
+
+	[auditlab@audit ~]$
+
+The recommended way to access the _audit.example.com_ is to SSH into the
+_audit.example.com_ host from the bastion workstation as shown below.  If done
+correctly you should not need to enter a password.
+
+* SSH command to login to _audit.example.com_ as "root"
+
+	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
+
+* SSH command to login to _audit.example.com_ as "auditlab"
+
+	[lab-user@workstation-GUID ~]$ ssh auditlab@audit.example.com
+
 == Configuring Audit
 
 There are two main audit components in Red Hat Enterprise Linux, the audit
@@ -31,8 +58,6 @@ can be modified using any text editor; but in this lab we will use the `sed`
 command to edit the _auditd.conf_ file.  While logged into the
 _audit.example.com_ system as "root", run the following commands to edit the
 _auditd.conf_ file:
-
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
 
 	[root@audit ~]# sed -e 's/^flush.*/flush = INCREMENTAL_ASYNC/' -i /etc/audit/auditd.conf
 	[root@audit ~]# sed -e 's/^freq.*/freq = 50/' -i /etc/audit/auditd.conf
@@ -65,8 +90,6 @@ Technical Implementation Guide (STIG) for Red Hat Enterprise Linux.  While
 logged into the _audit.example.com_ system as "root", run the following commands
 to enable a number of pre-defined audit filters:
 
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
-
 	[root@audit ~]# cat /usr/share/doc/audit-*/rules/README-rules
 	[root@audit ~]# rm /etc/audit/rules.d/*
 	[root@audit ~]# cp /usr/share/doc/audit-*/rules/10-base-config.rules /etc/audit/rules.d
@@ -95,8 +118,6 @@ http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)] manpage for
 more detail.  While logged into the _audit.example.com_ system as "root", run the
 following commands to add a custom audit filter for the `/usr/bin/ping`
 application:
-
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
 
 	[root@audit ~]# auditctl -a always,exit -F exe=/usr/bin/ping -k rhsummit
 
@@ -152,9 +173,9 @@ the system is configured as described earlier in this lab.
 
 === Generate Audit Events
 
-In order to ensure we have some interesting events in the audit log, login to
-the _audit.example.com_ system as the "auditlab" user and run the following
-commands:
+In order to ensure we have some interesting events in the audit log, from the
+workstation host, login to the _audit.example.com_ system as the "auditlab"
+user and run the following commands:
 
 	[lab-user@workstation-GUID ~]$ ssh auditlab@audit.example.com
 
@@ -177,8 +198,6 @@ The “-ts” option specifies at what point in the audit logs to start searchin
 “-m” option indicates that you are interested in audit events with the given
 record.  While logged into the _audit.example.com_ system as "root", run the
 following commands to see the login events on the test system:
-
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
 
 	[root@audit ~]# ausearch -ts today -m USER_LOGIN
 
@@ -225,8 +244,6 @@ http://man7.org/linux/man-pages/man8/aureport.8.html[aureport(8)] manpage.
 While logged into the _audit.example.com_ system as "root", run the following
 command to create an audit report for today's activity:
 
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
-
 	[root@audit ~]# aureport -ts today --summary
 
 The `aulast` tool generates a report similar to the `last` command, except the
@@ -261,8 +278,6 @@ http://man7.org/linux/man-pages/man8/ausearch.8.html[ausearch(8)] manpage.
 While logged into the _audit.example.com_ system as "root", run the following
 commands to see samples of the "csv" and "text" formats:
 
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
-
 	[root@audit ~]# ausearch -ts today --format csv
 	[root@audit ~]# ausearch -ts today --format text
 
@@ -288,8 +303,6 @@ system using `scp`, and then open the CSV file using LibreOffice:
 
 In order to reset the system used for the lab, run the following commands as
 "root" on _audit.example.com_:
-
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
 
 	[root@audit ~]# rm /etc/audit/rules.d/*
 	[root@audit ~]# cp /usr/share/doc/audit-*/rules/10-no-audit.rules /etc/audit/rules.d


### PR DESCRIPTION
Replace the missing commands with some text at the top of the lab
explaining the different prompts and how to access the audit test
system over SSH.