### PR TITLE
Unified shell session snippets across lab excercises.

### DIFF
--- a/2019Labs/CustomSecurityContent/documentation/lab0_setup.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab0_setup.adoc
@@ -17,4 +17,22 @@ There is only one VM, so click the only `CONSOLE` link on the page.
 Log in as `lab-user` using the password `r3dh4t1!`.
 You are all set!
 
+
+=== Conventions
+
+Shell session listings obey the following convention:
+
+----
+$ pwd
+/home/lab-user
+$ cat /etc/passwd
+...
+lab-user:x:1000:1000:Lab User:/home/lab-user:/bin/bash
+----
+
+- Commands, in this example `pwd` and `whoami`, are prefixed by the dollar character.
+- Lines that follow are the command's output, unless they begin with the dollar prefix, in which case they are again commands.
+- Ellipsis may be used to indicate that there are output lines, but as they are of no interest, they are omitted.
+
+
 link:README.adoc#table-of-contents[ Table of Contents ] | link:lab1_introduction.adoc[Lab 1: Introduction]

--- a/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
@@ -31,7 +31,7 @@
 * Make sure that you are in the project root when you start - run
 +
 ----
-cd /home/lab-user/labs/lab1_introduction/content
+$ cd /home/lab-user/labs/lab1_introduction/content
 ----
 +
 in the terminal.
@@ -75,7 +75,7 @@ Guide filenames have a `ssg-<product>-guide-<policy>.html` form, so the guide fo
 Give it a try - execute the following command in the terminal:
 
 ....
-firefox /home/lab-user/labs/lab1_introduction/content/build/guides/ssg-rhel8-guide-ospp.html
+$ firefox /home/lab-user/labs/lab1_introduction/content/build/guides/ssg-rhel8-guide-ospp.html
 ....
 
 As a security policy is an ordered list of rules, guide is an ordered list of descriptions of those rules.
@@ -169,10 +169,12 @@ In the following section, we will learn about parametrized rules by taking follo
 As the description says, the rule uses the `timeout` variable, that is defined in the `var_accounts_tmout.var` file.
 Similarly as in the previous step, we can search for the variable definition:
 +
-`find linux_os -name var_accounts_tmout.var`
+----
+$ find linux_os -name var_accounts_tmout.var
+linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
+----
 +
-You should get `linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var` as result.
-The file contains variable description, which is helpful - one can't be sure what the number 1800 means, however the contents of the file indicate that it is the same as 30 minutes, i.e. 1800 seconds.
+That `var_accounts_tmout.var` file contains variable description, which is helpful - one can't be sure what the number 1800 means, however the contents of the file indicate that it is the same as 30 minutes, i.e. 1800 seconds.
 
 . The rule is parametrized per profile.
 As there can be multiple profiles in one datastream file, one rule can exist in multiple profiles, and it can be parametrized differently in different profiles.
@@ -205,7 +207,7 @@ But we have things to do before the build finishes - let’s re-examine the vari
 Let's open the variable definition in an editor - execute
 +
 ....
-gedit linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
+$ gedit linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
 ....
 +
 In this YAML file, we have the `options:` key, that defines mappings between the supplied and effective values.
@@ -230,7 +232,7 @@ We can browse it if we open the directory in the `nautilus` file browser.
 Run
 
 ....
-nautilus linux_os/guide/system/accounts/accounts-session/accounts_tmout
+$ nautilus linux_os/guide/system/accounts/accounts-session/accounts_tmout
 ....
 
 in the terminal - a file explorer window opened at that location should pop up.

--- a/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
@@ -39,7 +39,7 @@ This section is for your reference only so you know what steps have already been
 You can verify a successful installation by running:
 
 ----
-oscap -V
+$ oscap -V
 
 OpenSCAP command line tool (oscap) 1.3.0
 Copyright 2009--2018 Red Hat Inc., Durham, North Carolina.
@@ -65,7 +65,7 @@ If during your own installation it says `oscap` command not found, you need to i
 . Let's take a look at the compliance content provided by `scap-security-guide`:
 +
 ----
-rpm -ql scap-security-guide
+$ rpm -ql scap-security-guide
 ...
 /usr/share/xml/scap/ssg/content/ssg-rhel8-cpe-dictionary.xml
 /usr/share/xml/scap/ssg/content/ssg-rhel8-cpe-oval.xml
@@ -83,13 +83,14 @@ There are also various formats in which this is provided - human readable HTML g
 . Move to the `content` folder so we can avoid typing long paths:
 +
 ----
-cd /usr/share/xml/scap/ssg/content
+$ cd /usr/share/xml/scap/ssg/content
 ----
 
 . First, let's check which compliance profiles are available for rhel7.
 +
 ----
-oscap info ssg-rhel8-ds.xml
+$ oscap info ssg-rhel8-ds.xml
+...
 ----
 +
 You will get print out of contents - aforementioned two compliance profiles. OSPP - Protection Profile for General Purpose Operating Systems, and PCI-DSS.
@@ -99,7 +100,8 @@ Notice in our command below that we can skip the profile ID prefix to make the c
 The real ID is xccdf_org.ssgproject.content_profile_ospp.
 +
 ----
-oscap xccdf eval --profile ospp ./ssg-rhel8-ds.xml
+$ oscap xccdf eval --profile ospp ./ssg-rhel8-ds.xml
+...
 ----
 +
 Now, you will see the compliance scan results for every security control in the OSPP security baseline profile.
@@ -109,13 +111,14 @@ Now, you will see the compliance scan results for every security control in the 
 * use `--report` to get human readable report (can also be generated from ARF after the scan as you see in the next optional step)
 
 ----
-oscap xccdf eval --profile ospp --results-arf /tmp/arf.xml --report /tmp/report.html ./ssg-rhel8-ds.xml
+$ oscap xccdf eval --profile ospp --results-arf /tmp/arf.xml --report /tmp/report.html ./ssg-rhel8-ds.xml
+...
 ----
 
 . (Optional) You can also generate the HTML report separately:
 +
 ----
-oscap xccdf generate report /tmp/arf.xml > /tmp/report.html
+$ oscap xccdf generate report /tmp/arf.xml > /tmp/report.html
 ----
 
 . Open the file explorer and head to the `/tmp` directory.
@@ -189,7 +192,7 @@ Let's go ahead and generate a playbook from the results:
 Use the `--fix-type ansible` option to request an ansible playbook with the fixes:
 +
 ----
-oscap xccdf generate fix --fix-type ansible --result-id "" arf.xml > playbook.yml
+$ oscap xccdf generate fix --fix-type ansible --result-id "" arf.xml > playbook.yml
 ----
 
 . (Optional) Generate bash remediation script and run it on target machine(s). This can be accomplished by running:
@@ -197,9 +200,10 @@ oscap xccdf generate fix --fix-type ansible --result-id "" arf.xml > playbook.ym
 * after the script is generated change its permissions so that we can run it
 +
 ----
-oscap xccdf generate fix --fix-type bash --result-id "" arf.xml > bash-fix.sh
-chmod +x bash-fix.sh
-./bash-fix.sh
+$ oscap xccdf generate fix --fix-type bash --result-id "" arf.xml > bash-fix.sh
+$ chmod +x bash-fix.sh
+$ ./bash-fix.sh
+...
 ----
 
 . Notice that in both cases we are using empty result-id.
@@ -285,10 +289,8 @@ After making this change, save and exit the text editor.
 Setting `ansible_python_interpreter` is workaround for known issue in Ansible 2.7 used on the machine.
 +
 ----
-ansible-playbook -i "localhost," -c local --check playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3'
-----
-+
-....
+$ ansible-playbook -i "localhost," -c local --check playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+
 [WARNING]: While constructing a mapping from /root/playbook.yml, line 26, column 7, found a duplicate dict key (var_accounts_passwords_pam_faillock_deny). Using last defined value only.
 
 [WARNING]: While constructing a mapping from /root/playbook.yml, line 26, column 7, found a duplicate dict key (var_accounts_passwords_pam_faillock_unlock_time). Using last defined value only.

--- a/2019Labs/CustomSecurityContent/documentation/lab3_profiles.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab3_profiles.adoc
@@ -31,7 +31,7 @@ In this lab excercise, we will show how to solve the task using ComplianceAsCode
 * Make sure that you are in the project root when you start - run
 +
 ----
-cd /home/lab-user/labs/lab3_profiles/content
+$ cd /home/lab-user/labs/lab3_profiles/content
 ----
 +
 in the terminal.
@@ -70,7 +70,7 @@ The profile will represent your company new security policy for laptops.
 . Go to the Red Hat Enterprise Linux 8 profiles directory.
 +
 ----
-cd rhel8/profiles
+$ cd rhel8/profiles
 ----
 +
 Notice that there are already some `.profile` files in the `profiles` directory.
@@ -79,7 +79,7 @@ You can get inspired by them.
 . Create new file `travel.profile` there and open it in the editor.
 +
 ----
-gedit travel.profile
+$ gedit travel.profile
 ----
 +
 . Create the basic structure and fill in the profile title and description as specified in this listing.
@@ -112,13 +112,13 @@ It cannot be an empty list, so for now we will add rule `security_patches_up_to_
 . Save the profile file and go back to the root directory.
 +
 ----
-cd ../..
+$ cd ../..
 ----
 +
 . Rebuild the content.
 +
 ----
-./build_product rhel8
+$ ./build_product rhel8
 ----
 +
 This command will rebuild contents for all the profiles in the Red Hat Enterprise Linux 8 product including you new “Travel” profile.
@@ -127,7 +127,7 @@ The command will build the human-readable HTML guide which can be displayed in a
 . Check the result HTML guide to look at your new profile.
 +
 ----
-firefox build/guides/ssg-rhel8-guide-travel.html
+$ firefox build/guides/ssg-rhel8-guide-travel.html
 ----
 +
 A Firefox Window will open and you will see the guide your Travel profile which contains just a single rule - `security_patches_up_to_date`.
@@ -150,14 +150,14 @@ In our case, we are looking if we have a `rule.yml` file in our repository which
 git grep for that.
 +
 ----
-git grep -i "SSH root login" "*rule.yml"
+$ git grep -i "SSH root login" "*rule.yml"
 linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml:title: 'Disable SSH Root Login'
 ----
 +
 If you want, you can check that this is the right rule by opening this `rule.yml` file and reading the description section in this file.
 +
 ----
-gedit linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+$ gedit linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
 ----
 +
 ----
@@ -181,7 +181,7 @@ In our case, the rule ID is `sshd_disable_root_login`.
 . Add the rule ID to selections list in your travel profile.
 +
 ----
-gedit rhel8/profiles/travel.profile
+$ gedit rhel8/profiles/travel.profile
 ----
 +
 Add `sshd_disable_root_login` as a new item in `selections` list.
@@ -204,7 +204,7 @@ selections:
 . Rebuild the content.
 +
 ----
-./build_product rhel8
+$ ./build_product rhel8
 ----
 +
 The rule `sshd_disable_root_login` will get included to your profile by the build system.
@@ -212,7 +212,7 @@ The rule `sshd_disable_root_login` will get included to your profile by the buil
 . Check the result HTML guide.
 +
 ----
-firefox build/guides/ssg-rhel8-guide-travel.html
+$ firefox build/guides/ssg-rhel8-guide-travel.html
 ----
 +
 A Firefox window will open and you will see your Travel profile which contains two rules.
@@ -234,7 +234,7 @@ We need to set the specific value (10 minutes) in the profile.
 This is similar to the previous section.
 +
 ----
-git grep -i "Interactive Session Timeout" "*rule.yml"
+$ git grep -i "Interactive Session Timeout" "*rule.yml"
 linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml:title: 'Set Interactive Session Timeout'
 ----
 +
@@ -244,7 +244,7 @@ It is easy to spot that the rule ID is `accounts_tmout` because the rule ID is t
 . Add the rule ID to selections list in your travel profile.
 +
 ----
-gedit rhel8/profiles/travel.profile
+$ gedit rhel8/profiles/travel.profile
 ----
 +
 Add `accounts_tmout` as a new item in selections list.
@@ -254,7 +254,7 @@ Make sure there is no trailing whitespace!
 . Check the rule contents to find out that there is a variable involved.
 +
 ----
-gedit linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+$ gedit linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
 ----
 +
 From the rule contents you can clearly see that it is parametrized by the `variable var_accounts_tmout`.
@@ -265,8 +265,9 @@ The value is also automatically substituted into OVAL checks, Ansible Playbooks 
 . Check out the variable.
 +
 ----
-find . -name var_accounts_tmout*
-gedit linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
+$ find . -name 'var_accounts_tmout*'
+linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
+$ gedit linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
 ----
 +
 The variable has multiple options, see the options list:
@@ -290,7 +291,7 @@ We will use the `10_min` selector to choose the 600 seconds.
 . Add the variable and the selector to the selections list in your `travel` profile.
 +
 ----
-gedit rhel8/profiles/travel.profile
+$ gedit rhel8/profiles/travel.profile
 ----
 +
 Same as the rule IDs, the variable values also belong to the `selections` list in the profile.
@@ -316,7 +317,7 @@ selections:
 . Rebuild the content.
 +
 ----
-./build_product rhel8
+$ ./build_product rhel8
 ----
 +
 The rule `accounts_tmout` will get included to your profile by the build system.
@@ -324,7 +325,7 @@ The rule `accounts_tmout` will get included to your profile by the build system.
 . Check the result HTML guide.
 +
 ----
-firefox build/guides/ssg-rhel8-guide-travel.html
+$ firefox build/guides/ssg-rhel8-guide-travel.html
 ----
 +
 Firefox will open and you will see your Travel profile which contains 3 rules.
@@ -349,7 +350,7 @@ We will also add arguments to turn on the full reporting, which will generate XM
 Run the following command:
 +
 ----
-sudo oscap xccdf eval --results results.xml --oval-results --report report.html --profile travel build/ssg-rhel8-ds.xml
+$ sudo oscap xccdf eval --results results.xml --oval-results --report report.html --profile travel build/ssg-rhel8-ds.xml
 ----
 +
 . Check the scan results.
@@ -364,7 +365,7 @@ image::2-02-terminal.png[Terminal]
 Open the HTML report using the following command:
 +
 ----
-firefox report.html
+$ firefox report.html
 ----
 +
 The structure of the HTML report is similar to the HTML guide, but it contains the evaluation results.
@@ -403,7 +404,7 @@ Let’s say that `package_hexchat_installed` could be a suitable ID.
 We will create the directory using `mkdir`, the `-p` switch makes sure that the directory is created along with it's parents if needed.
 +
 ----
-mkdir -p linux_os/guide/system/software/package_hexchat_installed
+$ mkdir -p linux_os/guide/system/software/package_hexchat_installed
 ----
 +
 . Create `rule.yml` in the rule directory.
@@ -413,7 +414,7 @@ Each rule needs to have it.
 The `rule.yml` is a simple YAML file.
 +
 ----
-gedit linux_os/guide/system/software/package_hexchat_installed/rule.yml
+$ gedit linux_os/guide/system/software/package_hexchat_installed/rule.yml
 ----
 +
 Add the following content to the `rule.yml` file using your editor.
@@ -468,7 +469,7 @@ Add the `hexchat` package to the list of installed packages to be checked.
 This list is called `package_installed.csv` and is located in the `templates/csv` directory.
 +
 ----
-gedit rhel8/templates/csv/packages_installed.csv
+$ gedit rhel8/templates/csv/packages_installed.csv
 ----
 +
 Add `hexchat` as a new line to this file and save the file.
@@ -476,13 +477,13 @@ Add `hexchat` as a new line to this file and save the file.
 . Build the content.
 +
 ----
-./build_product rhel8
+$ ./build_product rhel8
 ----
 +
 . Check the result HTML guide.
 +
 ----
-firefox build/guides/ssg-rhel8-guide-travel.html
+$ firefox build/guides/ssg-rhel8-guide-travel.html
 ----
 +
 A Firefox window will open and you will see your Travel profile which contains 4 rules.

--- a/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
@@ -231,7 +231,7 @@ Go back to the project root directory.
 Run the following command to build the RHEL8 product:
 
 ----
-./build_product rhel8
+$ ./build_product rhel8
 ----
 
 The Playbooks will be generated into the `build/rhel8/playbooks` directory.

--- a/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
@@ -34,9 +34,9 @@ The steps how to accomplish this are in the `tests/README.md` file of the `Compl
 * Open a terminal window by clicking `Activities` in the upper left corner, and then click on the terminal icon.
 * Make sure that you are in the project root when you start - run
 +
-.....
-cd /home/lab-user/labs/lab5_oval
-.....
+----
+$ cd /home/lab-user/labs/lab5_oval
+----
 +
 in the terminal.
 
@@ -421,7 +421,6 @@ Let's run the tests!
 ....
 $ ./build_product fedora
 ...
-...
 $ sudo tests/test_suite.py rule --container ssg_test_suite --datastream build/ssg-fedora-ds.xml accounts_tmout                                                            
 Setting console output to log level INFO
 INFO - The base image option has been specified, choosing Podman-based test environment.
@@ -500,7 +499,7 @@ Thanks to the OVAL optimization that we have performed before, there is only one
 So let's open the OVAL file again:
 
 ....
-gedit linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+$ gedit linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
 ....
 
 The current test object specifies


### PR DESCRIPTION

Shell session listings obey the following convention:

```$ pwd
/home/lab-user
$ cat /etc/passwd
...
lab-user:x:1000:1000:Lab User:/home/lab-user:/bin/bash
```

- Commands, in this example `pwd` and `whoami`, are prefixed by the dollar character.
- Lines that follow are the command's output, unless they begin with the dollar prefix, in which case they are again commands.
- Ellipsis may be used to indicate that there are output lines, but as they are of no interest, they are omitted.