### PR TITLE
Improve oscap formatting + Ansible setup

### DIFF
--- a/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
@@ -127,6 +127,8 @@ $ sudo oscap xccdf eval --profile ospp ssg-rhel8-ds.xml
 Now, you will see the compliance scan results for every security control in the OSPP security baseline profile.
 +
 . Now, let's store the results of the scan this time:
++
+--
 * use `--results-arf` to get machine readable results archive
 * use `--report` to get human readable report (can also be generated from ARF after the scan as you see in the next optional step)
 * use `--oval-results` to get detailed results in the report
@@ -135,13 +137,16 @@ Now, you will see the compliance scan results for every security control in the 
 $ sudo oscap xccdf eval --profile ospp --results-arf /tmp/arf.xml --report /tmp/report.html --oval-results ./ssg-rhel8-ds.xml
 ...
 ----
-+
-. (Optional) You can also generate the HTML report separately:
-+
+
+[NOTE]
+====
+You can also generate the HTML report separately by executing
 ----
 $ oscap xccdf generate report /tmp/arf.xml > /tmp/report.html
 ----
-+
+====
+--
+
 . Open the report in Firefox web browser.
 +
 ----
@@ -200,9 +205,12 @@ Close the *Diagnostics* window.
 +
 image:lab1.2-scapworkbenchscan.png[500,500]
 
-. (Optional) You can save the customization to a tailoring file by selecting File->Save Customization Only.
+[TIP]
+====
+You can save the customization to a tailoring file by selecting File->Save Customization Only.
 +
 image:lab1.2-savecustomization.png[300,300]
+====
 
 == Security Remediations with OpenSCAP, Ansible and Bash
 Putting the machine into compliance (for example by changing its configuration) is called *remediation* in the SCAP terminology.

--- a/2019Labs/CustomSecurityContent/setup/prep.yml
+++ b/2019Labs/CustomSecurityContent/setup/prep.yml
@@ -6,10 +6,9 @@
   become_user: lab-user
 
   vars:
-    LABS_LOCAL: "/home/lab-user/labs_data"
     LABS_CONTENT_PART: "2019Labs/CustomSecurityContent/documentation"
     TRACK_1_LABEL: "lab1_introduction"
-    TRACK_2_LABEL: "lab2_OpenSCAP"
+    TRACK_2_LABEL: "lab2_openscap"
     TRACK_3_LABEL: "lab3_profiles"
     TRACK_4_LABEL: "lab4_ansible"
     TRACK_5_LABEL: "lab5_oval"
@@ -17,15 +16,15 @@
     LABS_ROOT: "/home/lab-user/labs"
 
   tasks:
-  - name: Clone the Labs Git repository
-    git:
-      repo: 'https://github.com/RedHatDemos/SecurityDemos.git'
-      dest: "{{ LABS_LOCAL }}"
-
   - name: Clone the CaC/c Git repository
     git:
       repo: 'https://github.com/ComplianceAsCode/content.git'
       dest: "{{ CACC_LOCAL }}"
+
+  - name: Remove the Labs directory, so we start from scratch.
+    file:
+      path: "{{ LABS_ROOT }}"
+      state: absent
 
   - name: Generate SSH keys
     shell: ssh-keygen -b 2048 -t rsa -f /home/lab-user/.ssh/id_rsa -q -N ""
@@ -59,6 +58,11 @@
       chdir: "{{ CACC_LOCAL }}/Dockerfiles"
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
     become_user: root
+
+  - name: Remove the lab3 tests
+    file:
+      path: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/content/tests/data/group_system/group_accounts/group_accounts-session/"
+      state: absent
 
   - name: Creates directories for Lab Tracks
     file:
@@ -131,7 +135,14 @@
       regexp: '(operation=")greater than or equal(")'
       replace: '\1equals\2'
 
+  - name: Update the Ansible exercise to CaC master
+    git:
+      repo: "{{ CACC_LOCAL }}"
+      version: 'master'
+      dest: "{{ LABS_ROOT }}/{{ TRACK_4_LABEL }}/content"
+      force: yes
+
   - name: Remove the Ansible content from rule accounts_tmout so that the attendees can create them themselves
     file:
-      path: "{{ LABS_ROOT }}/{{ TRACK_4_LABEL }}/content/linux_os/system/accounts/accounts-session/accounts_tmout/ansible/"
+      path: "{{ LABS_ROOT }}/{{ TRACK_4_LABEL }}/content/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/"
       state: absent


### PR DESCRIPTION
Changes are small, so they are mashed together:

- introduced TIP boxes instead of optional content points.

Ansible changes:

- stopped cloning the documentation repository
- fixed the oscap lab case
- update the Ansible lab directory to CaC master
- fixed a typo in the "remove Ansible" step in the Ansible lab.