### PR TITLE
Update CustomSecurity lab exercises directory.

### DIFF
--- a/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
@@ -42,7 +42,7 @@ In Red Hat Enterprise Linux, the SCAP content generated from ComplianceAsCode da
 * Make sure that you are in the project root when you start - run
 +
 ----
-$ cd /home/lab-user/labs/lab1_introduction/content
+$ cd /home/lab-user/labs/lab1_introduction
 ----
 +
 in the terminal.
@@ -64,7 +64,7 @@ The build itself is based on Python, the `oscap` tool, and XSLT transformations.
 
 To build the content, take the following steps:
 
-. Make sure that you are in the good starting directory - `/home/lab-user/labs/lab1_introduction/content`.
+. Make sure that you are in the good starting directory - `/home/lab-user/labs/lab1_introduction`.
 . Run `./build_product rhel8` to compile content for Red Hat Enterprise Linux 8.
 +
 It is possible to build content also other for other products.

--- a/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
@@ -39,7 +39,7 @@ Several integrations for continuous scanning also exist but in this lab Exercise
 * Make sure that you are in the project root when you start - run
 +
 ----
-$ cd /home/lab-user/labs/lab2_openscap/content
+$ cd /home/lab-user/labs/lab2_openscap
 ----
 +
 in the terminal.

--- a/2019Labs/CustomSecurityContent/documentation/lab3_profiles.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab3_profiles.adoc
@@ -31,7 +31,7 @@ In this lab exercise, we will show how to solve the task using ComplianceAsCode.
 * Make sure that you are in the project root when you start - run
 +
 ----
-$ cd /home/lab-user/labs/lab3_profiles/content
+$ cd /home/lab-user/labs/lab3_profiles
 ----
 +
 in the terminal.

--- a/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
@@ -43,7 +43,7 @@ Moreover, it generates separated Playbooks for every rule.
 * Make sure that you are in the project root when you start - run
 +
 ----
-$ cd /home/lab-user/labs/lab4_ansible/content
+$ cd /home/lab-user/labs/lab4_ansible
 ----
 +
 in the terminal.


### PR DESCRIPTION
The content of directory "content" was moved to its parent folder, so it is not needed the /content anymore. Updated in all lab exercises where it was present.

In addition to: https://github.com/RedHatDemos/SecurityDemos/commit/4bb0e9639c1af620623c282e51844edda05a29de