### PR TITLE
Updated the lab wrt new upstream version of ComplianceAsCode.

### DIFF
--- a/2019Labs/CustomSecurityContent/documentation/lab0_setup.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab0_setup.adoc
@@ -1,8 +1,8 @@
-== Lab exercise 0: Setup steps
+= Lab exercise 0: Setup steps
 
 :imagesdir: images
 
-=== Accessing your dedicated lab environment using your provided GUID
+== Accessing your dedicated lab environment using your provided GUID
 
 . On your Red Hat Summit provided laptop, notice that the https://www.opentlc.com/gg/gg.cgi?profile=generic_summit[*Lab GUID Assignment page*^] is already loaded onto your Firefox web browser.
 From this page, you will be assigned your unique GUID, which you will use to access your unique lab environment and systems.

--- a/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
@@ -1,4 +1,4 @@
-= Lab 1: Say Hello to ComplianceAsCode
+= Lab Exercise 1: Say Hello to ComplianceAsCode
 
 :experimental:
 :imagesdir: images
@@ -33,16 +33,14 @@ In Red Hat Enterprise Linux, the SCAP content generated from ComplianceAsCode da
 ** and Python dependencies for putting content together: `python3-pyyaml`, `python3-jinja2`.
 
 
-=== Lab 1.1 Building the content
+== Lab 1 Hands-on
 
 The ComplianceAsCode project consists of human readable files that are compiled into standard-compliant files that are difficult to read and edit directly.
 
-Now let's go ahead and start building the content!
+For your convenience, we have set up the environment, so the content is built and ready to be used.
+No worries though - you will rebuild it later in the exercise.
 
-The https://github.com/ComplianceAsCode/content[ComplianceAsCode/content] project uses https://cmake.org/[CMake] build system.
-The build itself is based on: Python, the `oscap` tool, and XSLT transformations.
-
-To build the content, take the following steps:
+To start the hands-on section, take the following steps:
 
 . Log in to the VM using the text console if you haven't done so already:
 +
@@ -57,25 +55,14 @@ Don't forget to replace *GUID* with your lab provided *GUID*!
 
 . Go to the text console, i.e. the Terminal window of your laptop.
 Navigate to */home/lab-user/labs/lab1_introduction*.
-From this directory, run `./build_product rhel8` to compile content for Red Hat Enterprise Linux 8.
 +
 ----
 [... ~]$ cd /home/lab-user/labs/lab1_introduction
-[... lab1_introduction]$ ./build_product rhel8
+[... lab1_introduction]$
 ----
-+
-It is possible to also build content for other products.
-A product may be either an operating system, eg. RHEL 8, RHEL 7, Fedora, or they can be applications, e.g. Firefox, Java, and so on.
-+
-In general, you can run `./build_product <product>` to build only the content for a product you are interested in.
-The `<product>` is the lowercase form of the product, so you would run: `./build_product rhel8` to build content for RHEL 8, `./build_product fedora` to build content for Fedora, and so on.
 
-.Build of security content for RHEL 8 has finished in the terminal window.
-image::0-02-post_build.png[]
-{empty} +
-We will now explore the built content in the subsequent lab exercises.
 
-=== Lab 1.2 Viewing the provided HTML guides for the ComplianceAsCode project
+=== Lab 1.1 Viewing the provided HTML guides for the ComplianceAsCode project
 
 The `ComplianceAsCode` project provides HTML guides that are a great resource for those interested in what rules a policy consists of.
 The HTML guides are located in the respective `build/guides` of each lab exercise subdirectory. Therefore, the full path of the directory for this lab exercise is:
@@ -111,7 +98,7 @@ image::navigateospp.png[1000,1000]
 image::html_guide.png[]
 
 
-=== Lab 1.3 Updating a Rule Description to Find the Source of a Specific Rule
+=== Lab 1.2 Updating a Rule Description to Find the Source of a Specific Rule
 
 We will now take a closer look at a specific rule in the HTML guide of the RHEL 8 OSPP profile.
 For example, let's take a closer look at the *Set Interactive Session Timeout*  rule entry.
@@ -166,23 +153,44 @@ Remove the repeated text occurrence of *Setting the <tt>TMOUT</tt> option in <tt
 Press `Ctrl+x` to bring up the "save and exit" option, and confirm that you want to save the changes and exit by pressing `y` followed by `Enter`.
 
 . Now let's recompile the content to check whether our fix worked.
-Make sure that you are in the following directory: */home/lab-user/labs/lab1_introduction*.
-Then, recompile the content from this directory.
++
+The https://github.com/ComplianceAsCode/content[ComplianceAsCode/content] project uses https://cmake.org/[CMake] build system.
+The build itself is based on: Python, the `oscap` tool, and XSLT transformations.
++
+Make sure that you are in the `/home/lab-user/labs/lab1_introduction` directory in the Terminal window of your laptop.
+From this directory, run `./build_product rhel8` to compile content for Red Hat Enterprise Linux 8.
 +
 ----
 [... lab1_introduction]$ ./build_product rhel8
 ----
 +
-. Go back to the HTML guide of the RHEL 8 OSPP profile *that's open in Firefox of your lab environment's console*. Refresh your web browser.
+It is possible to also build content for other products.
+A product may be either an operating system, eg. RHEL 8, RHEL 7, Fedora, or they can be applications, e.g. Firefox, Java, and so on.
++
+In general, you can run `./build_product <product>` to build only the content for a product you are interested in.
+The `<product>` is the lowercase form of the product, so you would run: `./build_product rhel8` to build content for RHEL 8, `./build_product fedora` to build content for Fedora, and so on.
++
+.Build of security content for RHEL 8 has finished in the terminal window.
+image::0-02-post_build.png[]
+
+. Go back to the HTML guide of the RHEL 8 OSPP profile *that's open in Firefox of your lab environment's console*.
+Refresh your web browser.
 
 . Review the fix.
 You should see the fixed description now without the repeated *Setting the TMOUT option in /etc/profile ensures that* text if you scroll down to the *Set Interactive Session Timeout* rule.
 
 
-=== Lab 1.4 Customizing a Parametrized Rule
+=== Lab 1.3 Customizing a Parametrized Rule
 
-In this lab exercise, we will learn about parametrized rules. Parametrization can be used to set timeout durations, password length, umask, and other settings.
-We will learn about parametrized rules by: observing where the value comes from, changing the parametrized rule to see how it is applied, and finally, observing what happens when the parametrized variable is omitted.
+In this lab exercise, we will learn about parametrized rules.
+Parametrization can be used to set timeout durations, password length, umask, and other settings.
+We will learn about parametrized rules by:
+
+- observing where the value comes from,
+- changing the parametrized rule to see how it is applied, and finally,
+- observing what happens when the parametrized variable is omitted.
+
+{empty}
 
 . Modifying parametrized rules is very easy, as this rule doesn’t have the timeout duration hardcoded - it is parametrized by a variable.
 As the description for the *Set Interactive Session Timeout* rule says, the rule uses the `timeout` variable.
@@ -201,7 +209,6 @@ This is because there can be multiple profiles in one datastream file, one rule 
 +
 To see how the rule is connected to its variable, we have to check out the respective profile definition, i.e. `rhel8/profiles/ospp.profile`.
 Open it in the editor, and search for `accounts_tmout`
-//(use the `Ctrl + F` keyboard shortcut or use the `Edit->Find in this page` menu item to bring up the search field):
 +
 ----
 [... lab1_introduction]$ nano rhel8/profiles/ospp.profile
@@ -330,6 +337,7 @@ We will improve the remediation script by adding a comment there that describes 
 Let's edit the remediation file:
 
 ----
+[... accounts_tmout]$ cd /home/lab-user/labs/lab1_introduction
 [... lab1_introduction]$ nano linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
 ----
 

--- a/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
@@ -28,7 +28,7 @@ In Red Hat Enterprise Linux, the SCAP content generated from ComplianceAsCode da
 
 * The `ComplianceAsCode` repository has already been cloned to all of the `/home/lab-user/labs/` directories. So for example, `/home/lab-user/labs/lab1_introduction` is a clone of the ComplianceAsCode project repository.
 * The following dependencies that are required for the `ComplianceAsCode` content build have already been installed using `yum install`:
-** generic build utilities: `cmake`, `make`,
+** generic build utilities: `cmake`, `make` (`ninja` for faster builds),
 ** utilities for generating SCAP content: `openscap-utils`,
 ** and Python dependencies for putting content together: `python3-pyyaml`, `python3-jinja2`.
 

--- a/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
@@ -1,4 +1,4 @@
-= Lab exercies 2: Automated Security Scanning Using ComplianceAsCode
+= Lab Exercise 2: Automated Security Scanning Using ComplianceAsCode
 
 :imagesdir: images
 
@@ -41,7 +41,8 @@ OpenSCAP provides a command line tool `oscap` that can be used for automated sec
 You can verify a successful installation of `oscap` tool by running:
 
 ----
-[... lab1_introduction]$ oscap --version
+[... lab1_introduction]$ cd /home/lab-user/labs/lab2_openscap
+[... lab2_openscap]$ oscap --version
 
 OpenSCAP command line tool (oscap) 1.3.0
 Copyright 2009--2018 Red Hat Inc., Durham, North Carolina.
@@ -64,14 +65,7 @@ Notice that this command outputs the OpenSCAP version and versions of supported 
 
 In this Section we will build the security content for Red Hat Enterprise Linux 8 from ComplianceAsCode source code and then we will use the built content with OpenSCAP command line tool to scan our machine.
 
-. Build the content for Red Hat Enterprise Linux 8.
-+
-----
-[... lab1_introduction]$ cd /home/lab-user/labs/lab2_openscap
-[... lab2_openscap]$ ./build_product rhel8
-----
-+
-. Take a look at the generated files in the `build` directory.
+. The content has been built, so we can take a look at the generated files in the `build` directory right away:
 +
 ----
 [... lab2_openscap]$ cd build
@@ -113,33 +107,39 @@ Therefore, the `scap-security-guide` package in RHEL 8 contains only the OSPP an
 Notice in our command below that we can skip the profile ID prefix to make the command simpler.
 The real ID is `xccdf_org.ssgproject.content_profile_ospp`.
 +
-Run the command as the privileged user using the `sudo` command to scan the system parts that the common users does not have access.
+The scanning command has to be executed by a privileged user using `sudo`, so the scanner can access system parts that are off-limits to common users.
+The simplest scanner invocation can look like this:
 +
 ----
-[... build]$ sudo oscap xccdf eval --profile ospp ssg-rhel8-ds.xml
-...
+sudo oscap xccdf eval --profile ospp ssg-rhel8-ds.xml
 ----
 +
-Now, you will see the compliance scan results for every security control in the OSPP security baseline profile.
-+
-. Now, let's store the results of the scan this time:
+However, we will also want to store the scan results, so we can process them later.
+Therefore, we have to supply additional arguments:
 +
 --
 * use `--results-arf` to get machine readable results archive
 * use `--report` to get human readable report (can also be generated from ARF after the scan as you see in the next optional step)
 * use `--oval-results` to get detailed results in the report
-+
+
+So now, execute
+
 ----
 [... build]$ sudo oscap xccdf eval --profile ospp --results-arf /tmp/arf.xml --report /home/lab-user/labs/lab2_openscap/report.html --oval-results ./ssg-rhel8-ds.xml
 ...
 ----
 
+Now, you will see the compliance scan results for every security control in the OSPP security baseline profile.
+
 [NOTE]
 ====
 You can also generate the HTML report later by executing
+
 ----
-build]$ oscap xccdf generate report /tmp/arf.xml > /home/lab-user/labs/lab2_openscap/report.html
+[... build]$ sudo rm -f /home/lab-user/labs/lab2_openscap/report.html
+[... build]$ oscap xccdf generate report /tmp/arf.xml > /home/lab-user/labs/lab2_openscap/report.html
 ----
+
 ====
 --
 

--- a/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab2_openscap.adoc
@@ -25,7 +25,7 @@ Several integrations for continuous scanning also exist but in this lab Exercise
 
 * We have cloned the ComplianceAsCode repository to the `lab2_openscap` directory.
 * We have installed dependencies that are required for the ComplianceAsCode content build using `yum install`:
-** generic build utilities: `cmake`, `make`,
+** generic build utilities: `cmake`, `make` (`ninja` for faster builds),
 ** utilities for generating SCAP content: `openscap-utils`,
 ** and Python dependencies for putting content together: `python3-pyyaml`, `python3-jinja2`.
 * We have installed the OpenSCAP ecosystem packages, using `yum install`:
@@ -122,14 +122,14 @@ Therefore, we have to supply additional arguments:
 * use `--report` to get human readable report (can also be generated from ARF after the scan as you see in the next optional step)
 * use `--oval-results` to get detailed results in the report
 
-So now, execute
+So now, execute:
 
 ----
 [... build]$ sudo oscap xccdf eval --profile ospp --results-arf /tmp/arf.xml --report /home/lab-user/labs/lab2_openscap/report.html --oval-results ./ssg-rhel8-ds.xml
 ...
 ----
 
-Now, you will see the compliance scan results for every security control in the OSPP security baseline profile.
+to run the scan, generating the HTML report as a side-effect.
 
 [NOTE]
 ====

--- a/2019Labs/CustomSecurityContent/documentation/lab3_profiles.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab3_profiles.adoc
@@ -22,7 +22,7 @@ In this lab exercise, we will show how to solve the task using ComplianceAsCode.
 
 * We have cloned the ComplianceAsCode repository to the `lab3_profiles` directory.
 * We have installed dependencies that are required for the ComplianceAsCode content build using `yum install`:
-** generic build utilities: `cmake`, `make`,
+** generic build utilities: `cmake`, `make` (`ninja` for faster builds),
 ** utilities for generating SCAP content: `openscap-utils`,
 ** and Python dependencies for putting content together: `python3-pyyaml`, `python3-jinja2`.
 

--- a/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
@@ -31,6 +31,8 @@ Moreover, it generates separated Playbooks for every rule.
 == What we have done for you
 
 * We have cloned the ComplianceAsCode repository to the `lab4_ansible` directory.
+* We have installed Ansible.
+It is available from the `ansible-2.8-for-rhel-8-x86_64-rpms` repository, which is enabled automatically by the subscription manager.
 * We have installed dependencies that are required for the ComplianceAsCode content build using `yum install`:
 ** generic build utilities: `cmake`, `make`,
 ** utilities for generating SCAP content: `openscap-utils`,
@@ -391,42 +393,28 @@ However, security policies are usually complex which in turn means that profiles
 It is not convenient to have a separated Ansible Playbook for each rule, because that means to apply many Ansible Playbooks to the systems.
 Fortunately, ComplianceAsCode also generates Ansible Playbook that contain all tasks for a given profile in a single Playbook.
 
-The Playbooks are located in the `build/roles` directory.
-This directory contains both Ansible Playbooks and Bash remediation scripts for each profile.
+The Playbooks are located in the `build/ansible` directory.
+This directory contains both Ansible Playbooks for each profile.
 The Playbooks files have `.yml` extension.
 
 ----
-[... lab4_ansible]$ ls build/roles
-all-roles-rhel8-sh
-all-roles-rhel8-yml
-ssg-rhel8-role-cjis.sh
-ssg-rhel8-role-cjis.yml
-ssg-rhel8-role-cui.sh
-ssg-rhel8-role-cui.yml
-ssg-rhel8-role-default.sh
-ssg-rhel8-role-default.yml
-ssg-rhel8-role-hipaa.sh
-ssg-rhel8-role-hipaa.yml
-ssg-rhel8-role-ospp.sh
-ssg-rhel8-role-ospp.yml
-ssg-rhel8-role-pci-dss.sh
-ssg-rhel8-role-pci-dss.yml
-ssg-rhel8-role-rht-ccp.sh
-ssg-rhel8-role-rht-ccp.yml
-ssg-rhel8-role-standard.sh
-ssg-rhel8-role-standard.yml
+[... lab4_ansible]$ ls build/ansible
+all-profile-playbooks-rhel8
+rhel8-playbook-cjis.yml
+rhel8-playbook-cui.yml
+rhel8-playbook-default.yml
+rhel8-playbook-hipaa.yml
+rhel8-playbook-ospp.yml
+rhel8-playbook-pci-dss.yml
+rhel8-playbook-rht-ccp.yml
+rhel8-playbook-standard.yml
 ----
-
-Although the directory name is `roles`, and the files are called roles, these files are not Ansible Roles, but they are Ansible Playbooks.
 
 Check the contents of the OSPP profile Playbook in your editor and verify that a task for rule `accounts_tmout` is there among all the other tasks.
 
 ----
-[... lab4_ansible]$ nano build/roles/ssg-rhel8-role-ospp.yml
+[... lab4_ansible]$ nano build/ansible/rhel8-playbook-ospp.yml
 ----
-
-Keep in mind that even if the comments in the headers say that it is an Ansible Role, it is not an Ansible Role, it is an Ansible Playbook.
-This might be confusing.
 
 At this moment, you have per-rule Ansible playbooks available, as well as per-profile ones.
 You can integrate these into your CI/CD pipelines and infrastructure management as per your preferences.

--- a/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
@@ -32,9 +32,9 @@ Moreover, it generates separated Playbooks for every rule.
 
 * We have cloned the ComplianceAsCode repository to the `lab4_ansible` directory.
 * We have installed Ansible.
-It is available from the `ansible-2.8-for-rhel-8-x86_64-rpms` repository, which is enabled automatically by the subscription manager.
+It is available from the `ansible-2.8-for-rhel-8-x86_64-rpms` repository, which is enabled by the subscription manager.
 * We have installed dependencies that are required for the ComplianceAsCode content build using `yum install`:
-** generic build utilities: `cmake`, `make`,
+** generic build utilities: `cmake`, `make` (`ninja` for faster builds),
 ** utilities for generating SCAP content: `openscap-utils`,
 ** and Python dependencies for putting content together: `python3-pyyaml`, `python3-jinja2`.
 
@@ -394,7 +394,7 @@ It is not convenient to have a separated Ansible Playbook for each rule, because
 Fortunately, ComplianceAsCode also generates Ansible Playbook that contain all tasks for a given profile in a single Playbook.
 
 The Playbooks are located in the `build/ansible` directory.
-This directory contains both Ansible Playbooks for each profile.
+This directory contains Ansible Playbooks for each profile.
 The Playbooks files have `.yml` extension.
 
 ----

--- a/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
@@ -16,7 +16,7 @@
 
 * We have cloned the `ComplianceAsCode` repository to the `lab5_oval` directory.
 * We have installed dependencies that are required for the content build using `yum install`:
-** generic build utilities: `cmake`, `make`,
+** generic build utilities: `cmake`, `make` (`ninja` for faster builds),
 ** utilities for generating SCAP content: `openscap-utils`, and finally
 ** python dependencies for putting content together: `python3-pyyaml`, `python3-jinja2`.
 

--- a/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
@@ -73,15 +73,8 @@ Finally, we will discover that the check has been written incorrectly, and we wi
 
 === Lab 5.3 Anatomy of an existing check-remediation pair
 
-Select one of your terminals, go to the lab directory and build the content:
-
-----
-[... ~]$ cd /home/lab-user/labs/lab5_oval
-[... lab5_oval]$ ./build_product rhel8
-----
-
-When the build finishes, we will take a look at the RHEL8 OSPP profile.
-Open the file explorer, and open the guide in the browser:
+There is the already a built HTML guide in the build directory.
+To examine it, we navigate to it, and then we open the guide in the browser:
 
 Click on `Activites` at the top left of your desktop and click on the file cabinet icon to open the file explorer.
 
@@ -127,6 +120,7 @@ We want to make sure that the rule's check will allow both forms - with and with
 Let's examine the bash remediation - open the respective file in the text editor:
 
 ----
+[... ~]$ cd /home/lab-user/labs/lab5_oval
 [... lab5_oval]$ nano linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
 ----
 

--- a/2019Labs/CustomSecurityContent/setup/data/ospp.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp.profile
@@ -1,0 +1,851 @@
+documentation_complete: true
+
+title: 'Protection Profile for General Purpose Operating Systems'
+
+description: |-
+    This profile reflects mandatory configuration controls identified in the
+    NIAP Configuration Annex to the Protection Profile for General Purpose
+    Operating Systems (Protection Profile Version 4.2).
+
+selections:
+
+    #######################################################
+    # 5.1.1 Cryptographic Support (FCS)
+
+    #######################################################
+    ## FCS_CKM.1 Cryptographic Key Generation
+
+    ### FCS_CKM.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_CKM.1.1
+    ### The OS shall generate asymetric cryptographic
+    ### keys in accordance with a specified cryptographic key
+    ### generation algorithm.
+
+
+    ### FCS_CKM.2.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_CKM.2.1
+    ### The OS shall implement functionality to perform cryptographic
+    ### key establishment in accordance with a specified cryptographic
+    ### key establishment method
+
+    #######################################################
+    ## FCS_CKM_EXT.4 Cryptographic Key Destruction
+
+    ### FCS_CKM_EXT.4.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_CKM_EXT.4.1
+    ### The OS shall destroy cryptographic keys and key material in accordance
+    ### with a specified cryptographic key destruction method
+
+    ### FCS_CKM_EXT.4.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_CKM_EXT.4.2
+    ### The OS shall destroy all keys and key material when no longer needed
+
+    #######################################################
+    ## FCS_COP.1(1) Cryptographic Operation - Encryption/Decryption (Refined)
+
+    ### FCS_COP.1.1(1): https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_COP.1.1(1)
+    ### The OS shall perform encryption/decryption services for data
+    ### in accorance with a specified cryptographic algorithm
+
+    #######################################################
+    ## FCS_COP.1(2) Cryptographic Operation - Hashing (Refined)
+
+    ### FCS_COP.1.1(2): https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_COP.1.1(2)
+    ### The OS shall perform cryptographic hashing services in accordance
+    ### with a specified cryptographic algorithm SHA-1 and [selection]
+    ###         - SHA-256
+    ###         - SHA-384
+    ###         - SHA-512
+    ###         - no other algorithm
+
+    ### and message digest sizes 160 bits and [selection]
+    ###         - 256 bits
+    ###         - 384 bits
+    ###         - 512 bits
+    ###         - no other sizes
+
+    ### that meet the following: FIPS Pub 180-4
+
+
+    ### FCP_COP.1.1(3): https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_COP.1.1(3)
+    ### The OS shall perform cryptographic signature services (generation
+    ### and verification) in accordance with a specified algorithm
+
+
+    ### FCP_COP.1.1(4): https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_COP.1.1(4)
+    ### The OS shall perform keyed-hash message authentication services in
+    ### accordance with a specified cryptographic algorithm [selection]
+    ###     - SHA-1
+    ###     - SHA-256
+    ###     - SHA-384
+    ###     - SHA-512
+
+    ### with key size (in bits) used in HMAC
+
+    ### and message digest sizes [selection]
+    ###     - 160 bits
+    ###     - 256 bits
+    ###     - 384 bits
+    ###     - 512 bits
+
+    #######################################################
+    ## FCS_RBG_EXT.1 Random Bit Generation
+
+    ### FCS_RBG_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_RBG_EXT.1.1
+    ### The OS shall perform all deterministic random bit generation (DRBG)
+    ### services in accordance with NIST Special Publication 800-90A using
+    ### [selection]
+    ###     - HASH_DRBG (any),
+    ###     - HMAC_DRBG (any),
+    ###     - CTR_DRBG (AES)
+
+
+    ### FCS_RBG_EXT.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_RBG_EXT.1.2
+    ### The deterministic RBG used by the OS shall be seeded by an entropy source
+    ### that accumulates entropy from a [selection]
+    ###     - software-based noise source,
+    ###     - platform-based noise source
+
+    ### with a minimum of [selection]
+    ###     - 128 bits
+    ###     - 256 bits
+    ### of entropy at least equal to the greatest strength (according to NIST
+    ### 800-57) of the keys and hashes that it will generate.
+
+    #######################################################
+    ## FCS_STO_EXT.1 Storage of Sensitive Data
+
+    ### FCS_STO_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_STO_EXT.1.1
+    ### The OS shall implement functionality to encrypt sensitive data stored
+    ### in non-volatile storage and provide interfaces to applications to
+    ### invoke this functionality
+
+    #######################################################
+    ## FCS_TLSC_EXT.1 TLS Client Protocol
+
+    ### FCS_TLSC_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_TLSC_EXT.1.1
+    ### The OS shall implement TLS 1.2 (RFC 5246) supporting the following
+    ### cipher suites: [selection:
+    ###     - TLS_RSA_WITH_AES_128_CBC_SHA as defined in RFC 5246,
+    ###     - TLS_RSA_WITH_AES_128_CBC_SHA256 as defined in RFC 5246,
+    ###     - TLS_RSA_WITH_AES_256_CBC_SHA256 as defined in RFC 5246,
+    ###     - TLS_RSA_WITH_AES_256_CBC_SHA384 as defined in RFC 5288,
+    ###     - TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 as defined in RFC 5246,
+    ###     - TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 as defined in RFC 5246,
+    ###     - TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 as defined in RFC 5288,
+    ###     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 as defined in RFC 5289,
+    ###     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 as defined in RFC 5289,
+    ###     - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384 as defined in RFC 5289,
+    ###     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 as defined in RFC 5289,
+    ###     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 as defined in RFC 5289,
+    ###     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as defined in RFC 5289,
+    ###     - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 as defined in RFC 5289,
+    ###     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 as defined in RFC 5289
+
+
+    ### FCS_TLSC_EXT.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_TLSC_EXT.1.2
+    ### The OS shall verify that the presented identifier matches the reference
+    ### identifier according to RFC 6125
+
+
+    ### FCS_TLSC_EXT.1.3: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_TLSC_EXT.1.3
+    ### The OS shall only establish a trusted channel of the peer certificate is valid
+
+
+    #######################################################
+    # 5.1.2 User Data Protection (FDP)
+
+    #######################################################
+    ## FDP_ACF_EXT.1 Access Controlls for Protecting User Data
+
+    ### FDP_ACF_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FDP_ACF_EXT.1.1
+    ### The OS shall implement access controls which can prohibit
+    ### unprivileged users from accessing files and directories
+    ### owned by other users
+
+    #######################################################
+    # 5.1.3 Security Management (FMT)
+
+    #######################################################
+    ## FMT_MOF_EXT.1 Management of security functions behavior
+
+    ### FMT_MOF_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FMT_MOF_EXT.1.1
+    ### The OS shall restrict the ability to perform the function
+    ### indicated in the "Administrator" column in FMT_SMF_EXT.1.1 to
+    ### the administrator
+
+    #### enable/disable screen lock
+
+    #### enable/disable session timeout
+
+    #### configure screen lock inactivity timeout
+
+    #### configure session inactivity timeout
+    - dconf_gnome_disable_user_admin
+
+
+    #######################################################
+    ## FMT_SMF_EXT.1 Specification of Management Functions
+
+    ### FMT_SMF_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FMT_SMF_EXT.1.1
+    ### The OS shall be capable of performing the following
+    ### management functions:
+
+    ### NOTE: rules below are from the NIAP Configuration Annex at
+    ### https://www.niap-ccevs.org/MMO/PP/424.CANX/
+
+    ### FMT_MOF_EXT.1 / IA-5(1)(a)
+    ### Configure Minimum Password Length to 12 Characters
+    - var_password_pam_minlen=12
+    - accounts_password_pam_minlen
+    - accounts_password_minlen_login_defs
+
+    ### FMT_MOF_EXT.1 / IA-5(1)(a)
+    ### Require at Least 1 Special Character in Password
+    - var_password_pam_ocredit=1
+    - accounts_password_pam_ocredit
+
+    ### FMT_MOF_EXT.1 / IA-5(1)(a)
+    ### Require at Least 1 Numeric Character in Password
+    - var_password_pam_dcredit=1
+    - accounts_password_pam_dcredit
+
+    ### FMT_MOF_EXT.1 / IA-5(1)(a)
+    ### Require at Least 1 Uppercase Character in Password
+    - var_password_pam_ucredit=1
+    - accounts_password_pam_ucredit
+
+    ### FMT_MOF_EXT.1 / IA-5(1)(a)
+    ### Require at Least 1 Lowercase Character in Password
+    - var_password_pam_lcredit=1
+    - accounts_password_pam_lcredit
+
+    ### FMT_MOF_EXT.1 / AC-11(a)
+    ### Enable Screen Lock
+    - package_tmux_installed
+    - dconf_use_text_backend
+    - dconf_gnome_screensaver_idle_activation_enabled
+    - dconf_gnome_screensaver_idle_delay
+    - dconf_gnome_screensaver_lock_delay
+    - dconf_gnome_screensaver_lock_enabled
+    - dconf_gnome_screensaver_mode_blank
+    - dconf_gnome_screensaver_user_info
+    - dconf_gnome_screensaver_user_locks
+    - dconf_gnome_session_idle_user_locks
+    - configure_tmux_lock_command
+
+    ### FMT_MOF_EXT.1 / AC-11(a)
+    ### Set Screen Lock Timeout Period to 30 Minutes or Less
+    - accounts_tmout
+    - var_accounts_tmout=30_min
+
+    ### FIA_AFL.1
+    ### Disable Unauthenticated Login (such as Guest Accounts)
+    - no_empty_passwords
+    - grub2_password
+    - grub2_uefi_password
+    - grub2_disable_interactive_boot
+    - require_singleuser_auth
+    - service_debug-shell_disabled
+    - sshd_disable_empty_passwords
+    - sshd_disable_root_login
+    - gnome_gdm_disable_automatic_login
+    - gnome_gdm_disable_guest_login
+    - sssd_offline_cred_expiration
+    - sssd_memcache_timeout
+    - var_sssd_memcache_timeout=1_day
+    - disable_host_auth
+    - sshd_disable_gssapi_auth
+    - sshd_disable_kerb_auth
+    - sshd_disable_rhosts_rsa
+    - sshd_disable_rhosts
+    - sshd_disable_user_known_hosts
+
+    ### FMT_MOF_EXT.1 / AC-7(a)
+    ### Set Maximum Number of Authentication Failures to
+    ### 3 within 15 minutes
+    - var_accounts_passwords_pam_faillock_deny=3
+    - var_accounts_passwords_pam_faillock_fail_interval=900
+    - var_accounts_passwords_pam_faillock_unlock_time=never
+    - var_password_pam_retry=3
+    - accounts_password_pam_retry
+    - accounts_passwords_pam_faillock_deny_root
+    - accounts_passwords_pam_faillock_deny
+    - accounts_passwords_pam_faillock_interval
+    - accounts_passwords_pam_faillock_unlock_time
+    - dconf_gnome_login_retries
+
+    ### FMT_MOF_EXT.1 / SC-7(12)
+    ### Enable Host-Based Firewall
+    - service_firewalld_enabled
+    - set_firewalld_default_zone
+
+
+    ### FMT_MOF_EXT.1 / CM-3(3)
+    ### Configure Name/Address of Remote Management
+    ### Server From Which to Receive Config Settings
+
+
+    ### FAU_GEN.1.1.c / AU-4(1)
+    ### Configure the System to Offload Audit Records to a Log Server
+    - rsyslog_remote_loghost
+    - auditd_audispd_syslog_plugin_activated
+    - auditd_audispd_configure_remote_server
+    - auditd_audispd_encrypt_sent_records    
+
+    ### FMT_MOF_EXT.1 / AC-8(a)
+    ### Set Logon Warning Banner
+    - dconf_gnome_banner_enabled
+    - dconf_gnome_login_banner_text
+    - banner_etc_issue
+    - sshd_enable_warning_banner
+    - login_banner_text=usgcb_default
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit All Logons (Success/Failure)
+    ### and Logoffs (Successful)
+
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit File and Object Events (Unsuccessful)
+
+    #### CREATE (Unsuccessful)
+    - audit_rules_unsuccessful_file_modification_creat
+
+    #### ACCESS (Unsuccessful)
+    - audit_rules_unsuccessful_file_modification_openat_o_creat
+    - audit_rules_unsuccessful_file_modification_openat_o_trunc_write
+    - audit_rules_unsuccessful_file_modification_openat
+    - audit_rules_unsuccessful_file_modification_openat_rule_order
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order
+    - audit_rules_unsuccessful_file_modification_open_o_creat
+    - audit_rules_unsuccessful_file_modification_open_o_trunc_write
+    - audit_rules_unsuccessful_file_modification_open
+    - audit_rules_unsuccessful_file_modification_open_rule_order
+
+    #### DELETE (Unsuccessful)
+    - audit_rules_unsuccessful_file_modification_unlink
+    - audit_rules_unsuccessful_file_modification_unlinkat
+ #   - audit_rules_file_deletion_events_renameat
+ #   - audit_rules_file_deletion_events_rename
+ #   - audit_rules_file_deletion_events_rmdir
+ #   - audit_rules_file_deletion_events_unlinkat
+ #   - audit_rules_file_deletion_events_unlink
+
+    #### MODIFY (Unsuccessful)
+    - audit_rules_unsuccessful_file_modification_ftruncate
+    - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_unsuccessful_file_modification_rename
+    - audit_rules_unsuccessful_file_modification_renameat
+#   - audit_rules_privileged_commands_passwd
+#    - audit_rules_privileged_commands_unix_chkpwd
+#    - audit_rules_privileged_commands_userhelper
+#    - audit_rules_privileged_commands_usernetctl
+#    - audit_rules_privileged_commands_chage
+#    - audit_rules_privileged_commands_chsh
+#    - audit_rules_privileged_commands_pt_chown
+
+    #### PERMISSION MODIFICATION (Unsuccessful)
+#    - audit_rules_dac_modification_chmod
+#    - audit_rules_dac_modification_fchmodat
+#    - audit_rules_dac_modification_fchmod
+#    - audit_rules_dac_modification_fremovexattr
+#    - audit_rules_dac_modification_fsetxattr
+#    - audit_rules_dac_modification_lremovexattr
+#    - audit_rules_dac_modification_lsetxattr
+#    - audit_rules_dac_modification_removexattr
+#    - audit_rules_dac_modification_setxattr
+#    - audit_rules_execution_chcon
+#    - audit_rules_execution_restorecon
+#    - audit_rules_execution_semanage
+#    - audit_rules_execution_seunshare
+#    - audit_rules_execution_setsebool
+#    - audit_rules_mac_modification
+
+
+    #### OWNERSHIP MODIFICATION (Unsuccessful)
+    - audit_rules_unsuccessful_file_modification_chown
+    - audit_rules_unsuccessful_file_modification_fchownat
+    - audit_rules_unsuccessful_file_modification_fchown
+    - audit_rules_unsuccessful_file_modification_lchown
+#    - audit_rules_dac_modification_chown
+#    - audit_rules_dac_modification_fchownat
+#    - audit_rules_dac_modification_fchown
+#    - audit_rules_dac_modification_lchown
+
+
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit User and Group Management Events (Success/Failure)
+
+    #### USER ADD (Success/Failure)
+
+
+    #### USER DELETE (Success/Failure)
+
+
+    #### USER MODIFY (Success/Failure)
+    - audit_rules_usergroup_modification_passwd
+    - audit_rules_usergroup_modification_shadow
+    - audit_rules_etc_shadow_open
+    - audit_rules_etc_shadow_openat
+    - audit_rules_etc_shadow_open_by_handle_at
+    - audit_rules_etc_passwd_open
+    - audit_rules_etc_passwd_openat
+    - audit_rules_etc_passwd_open_by_handle_at
+
+    #### USER DISABLE (Success/Failure)
+
+
+    #### USER ENABLE (Success/Failure)
+
+
+    #### GROUP/ROLE ADD (Succes/Failure)
+    - audit_rules_privileged_commands_newgidmap
+    - audit_rules_privileged_commands_newgrp
+    - audit_rules_privileged_commands_newuidmap
+
+    ##### GROUP/ROLE DELETE (Success/Failure)
+
+
+    ##### GROUP/ROLE MODIFY (Success/Failure)
+    - audit_rules_privileged_commands_gpasswd
+    - audit_rules_usergroup_modification_group
+    - audit_rules_usergroup_modification_gshadow
+    - audit_rules_etc_gshadow_open
+    - audit_rules_etc_gshadow_openat
+    - audit_rules_etc_gshadow_open_by_handle_at
+    - audit_rules_usergroup_modification_opasswd
+    - audit_rules_etc_group_open
+    - audit_rules_etc_group_openat
+    - audit_rules_etc_group_open_by_handle_at
+
+    - audit_rules_privileged_commands_sudoedit
+
+
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit Privilege and Role Escalation Events (Success/Failure)
+    - audit_rules_privileged_commands_sudo
+    - audit_rules_privileged_commands_su
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit All Audit and Log Data Accesses (Success/Failure)
+    - audit_rules_login_events_faillock
+    - audit_rules_login_events_lastlog
+    - audit_rules_login_events_tallylog
+    - directory_access_var_log_audit
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit Cryptographic Verification of Software (Success/Failure)
+
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit Program Initiations (Success/Failure)
+
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit System Reboot, Restart, and Shutdown
+    ### Events (Success/Failure)
+
+
+    ### FAU_GEN.1.1.c / AU-2(a)
+    ### Audit Kernel Module Loading and Unloading Events (Success/Failure)
+    - audit_rules_kernel_module_loading_delete
+    - audit_rules_kernel_module_loading_init
+    - audit_rules_kernel_module_loading_insmod
+    - audit_rules_kernel_module_loading_modprobe
+    - audit_rules_kernel_module_loading_rmmod
+
+    ### FMT_MOF_EXT.1 / SI-2
+    ### Enable Automatic Software Update
+
+
+    #######################################################
+    # 5.1.4 Protection of the TSF (FPT)
+
+    #######################################################
+    ## FPT_ACF_EXT.1 Access Controls
+
+    ### FPT_ACF_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_ACF_EXT.1.1
+    ### The OS shall implement access controls which prohibit
+    ### unprivileged users from modifying:
+    ###     - kernel and its drivers/modules
+    ###     - security audit logs
+    ###     - shared libraries
+    ###     - system executables
+    ###     - system configuration files
+    ###     - [assignment: other objects]
+
+    ### FPT_ACF_EXT.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_ACF_EXT.1.2
+    ### The OS shall implement access controls which prohibit
+    ### unprivileged users from reading:
+    ###     - security audit logs
+    ###     - system-wide credential repositories
+    ###     - [assignment: list of other objects]
+
+    #######################################################
+    ## FPT_ASLR_EXT.1 Address Space Layout Randomization
+
+    ### FPT_ASLR_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_ASLR_EXT.1.1
+    ### The OS shall always randomize address space memory locations
+    ### with [selection: 8, [assignment: number greater than 8]] bits of
+    ### entropy except for [assignment: list of explicity exceptions]
+
+    #######################################################
+    ## FPT_SBOP_EXT.1 Stack Buffer Overflow Protection
+
+    ### FPT_SBOP_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_SBOP_EXT.1.1
+    ### The OS shall [selection: employ stack-based buffer overflow protections,
+    ### not store parameters/variables in the same data structures as control
+    ### flow values].
+
+    #######################################################
+    ## FPT_TST_EXT.1 Boot Integrity
+
+    ### FPT_TST_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TST_EXT.1.1
+    ### The OS shall verify the integrity of the bootchain up through
+    ### the OS kernel and [selection:
+    ###     - all executable code stored in mutable media,
+    ###     - [assignment: list of other executable code],
+    ###     - no other executable code
+    ###
+    ### ] prior to its execution through the use of [selection:
+    ###     - a digital signature using a hardware-protected
+    ###       asymetric key,
+    ###     - a hardware-protected hash]
+
+    #######################################################
+    ## FPT_TUD_EXT.1 Trusted Update
+
+    ### FPT_TUD_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TUD_EXT.1.1
+    ### The OS shall provide the ability to check for updates
+    ### to the OS software itself.
+    - security_patches_up_to_date
+
+    ### FPT_TUD_EXT.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TUD_EXT.1.2
+    ### The OS shall cryptographically verify updates to itself using
+    ### a digital signature prior to installation using schemes specified
+    ### in FCS_COP.1(3).
+
+    #######################################################
+    ## FPT_TUD_EXT.2 Trusted Update for Application Software
+
+    ### FPT_TUD_EXT.2.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TUD_EXT.2.1
+    ### The OS shall provide the ability to check for updates to
+    ### application software
+
+    ### FPT_TUD_EXT.2.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TUD_EXT.2.2
+    ### The OS shall cryptographically verify the integrity of updates
+    ### to applications using a digital signature specified by FCS_COP.1(3)
+    ### prior to installation.
+
+
+    #######################################################
+    # 5.1.5 Audit Data Generation (FAU)
+
+    #######################################################
+    ## FAU_GEN.1 Audit Data Generation (Refined)
+
+    ### FAU_GEN.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FAU_GEN.1.1
+    ### The OS shall be able to generate an audit record
+    ### of the following auditable events:
+    ###
+    ### RESPONSE: This requirement regards capability,
+    ###           no configuration action needed.
+
+    ### FAU_GEN.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FAU_GEN.1.2
+    ### The OS shall record within each audit record at least
+    ### the following information:
+    ###
+    ###     a. Date and time of the event, type of event, subject
+    ###        identity (if applicable), and outcome (success or failure)
+    ###        of the event; and
+    ###     b. For each audit event type, based on the auditable event
+    ###        definitions of the functional components included in the
+    ###        PP/ST, [assignment: other audit relevant information]
+
+    #######################################################
+    # 5.1.6 Identification and Authentication (FIA)
+
+    #######################################################
+    ## FIA_AFL.1 Authentication failure handling (Refined)
+
+    ### FIA_AFL.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_AFL.1.1
+    ### The OS shall detet when [selection:
+    ###     - [assignment: positive integer number],
+    ###     - an administrator configurable positive integer within
+    ###       [assignment: range of acceptable values]
+    ### ] unsuccessful authentication attempts occur related to
+    ### events with [selection:
+    ###     - authentication based on user name and password,
+    ###     - authentication based on user name and a PIN that releases
+    ###       an asymmetric key stored in OE-protected storage,
+    ###     - authentication based on X.509 certificates
+    ### ]
+
+    ### FIA_AFL.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_AFL.1.2
+    ### When the defined number of unsuccesful authentication attempts
+    ### for an account has been met, the OS shall: [selection:
+    ### Account Lockout, Account Disablement, Mandatory Credential Reset,
+    ### [assignment: list of actions]].
+
+    #######################################################
+    ## FIA_UAU.5 Multiple Authentication Mechanisms (Refined)
+
+    ### FIA_UAU.5.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_UAU.5.1
+    ### The OS shall provide the following authentication mechanisms
+    ### [selection:
+    ###     - authentication based on user name and password,
+    ###     - authentication based on user name and a PIN that releases
+    ###       an asymmetric key stored in OE-protected storage,
+    ###     - authentication based on X.509 certificates,
+    ###     - for use in SSH only, SSH public key-based authentication
+    ###       as specified by the EP.for Secure Shell
+    ### ] to support user authentication.
+
+    ### FIA_UAU.5.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_UAU.5.2
+    ### The OS shall authenticate any user's claimed identity according to
+    ### [assignment: rules describing how the multiple authentication
+    ### mechanisms provide authentication].
+
+    #######################################################
+    ## FIA_X509_EXT.1 X.509 Certificate Validation
+
+    ### FIA_X509_EXT.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_X509_EXT.1.1
+    ### The OS shall implement functionality to validate certificates
+    ### in accordance with the following rules:
+    ###     - RFC 5280 certificate validation and certificate path validation
+    ###     - The certificate path must terminate with a trusted CA certificate
+    ###     - The OS shall validate a certificate path by ensuring the presense
+    ###       of the basicConstraints extension and that the CA flag is set to
+    ###       TRUE for all CA certificates
+    ###     - The OS shall validate the revocation status of the certificate
+    ###       using [selection: the Online Certificate Status Protocol (OSCP)
+    ###       as specified RFC 2560, a Certificate Revocation List (CRL) as
+    ###       specified in RFC 5759, an OCSP TLS Status Request Extension
+    ###       (i.e., OSCP stapling) as specified in RFC 6066].
+    ###     - The OS shall validate the extendedKeyUsage field according to the
+    ###       following rules:
+    ###         * Certificates used for trusted updates and executable code
+    ###           integrity verification shall have the Code Signing purpose
+    ###           (id-kp 3 with OID 1.3.6.1.5.5.7.3.3) in the extendedKeyUsage
+    ###           field.
+    ###         * Server certificates presented for TLS shall have the Server
+    ###           Authentication purpose (id-kp 1 with OID 1.3.6.1.5.5.7.3.1)
+    ###           in the extendedKeyUsage field.
+    ###         * Client certificates presented for TLS shall have the Client
+    ###           Authentication purpose (id-kp 2 with OID 1.3.6.1.5.5.7.3.2) in the
+    ###           extendedKeyUsage field.
+    ###         * S/MIME certificates presented for email encryption and signature
+    ###           shall have the Email Protection purpose (id-kp 4 with OID
+    ###           1.3.6.1.5.5.7.3.4) in the extendedKeyUsage field.
+    ###         * OCSP certificates presented for OCSP responses shall have the OCSP
+    ###           Signing purpose (id-kp 9 with OID 1.3.6.1.5.5.7.3.9) in the
+    ###           extendedKeyUsage field.
+    ###         * (Conditional) Server certificates presented for EST shall have the
+    ###           CMC Registration Authority (RA) purpose (id-kp-cmcRA with OID
+    ###           1.3.6.1.5.5.7.3.28) in the extendedKeyUsage field.
+
+    #######################################################
+    ## FIA_X509_EXT.2 X.509 Certificate Authentication
+
+    ### FIA_X509_EXT.2.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_X509_EXT.2.1
+    ### The OS shall use X.509v3 certificates as defined by RFC 5280 to
+    ### support authentication for TLS and [selection: DTLS, HTTPS, [assignment:
+    ### other protocols], no other protocols] connections.
+
+    #######################################################
+    # 5.1.7 Trusted Path/Channels (FTP)
+
+    #######################################################
+    ## FTP_ITC_EXT.1 Trusted channel communication
+
+    ### FTP_ITC_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FTP_ITC_EXT.1.1
+    ### The OS shall use [selection:
+    ###     - TLS as conforming to FCS_TLSC_EXT.1,
+    ###     - DTLS as conforming to FCS_DTLS_EXT.1,
+    ###     - IPsec as conforming to the EP for IPsec VPN Clients,
+    ###     - SSH as conforming to EP for Secure Shell
+    ### ] to provide a trusted communication channel between itself and authorized
+    ### IT entities supporting the following capabilities: [sekection: audit server,
+    ### authentication server, management server, [assignment: other capabilities]]
+    ### that is logically distinct from other communication channels and provides
+    ### assured identification of its end points and protection of the channel data
+    ### from disclosure and detection of modification of the channel data.
+
+    #######################################################
+    ## FTP_TRP.1 Trusted Path
+
+    ### FTP_TRP.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FTP_TRP.1.1
+    ### The OS shall provide a communication path between itself and
+    ### [selection: remote, local] users that is logically distinct from other
+    ### communication paths and provides assured identification of its endpoints
+    ### and protection of the communicated data from modification and disclosure.
+
+
+    ### FTP_TRP.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FTP_TRP.1.2
+    ### The OS shall permid [selection: the TSF, local users, remote users]
+    ### to initiate communication via the trusted path.
+
+
+    ### FTP_TRP.1.3: https://www.niap-ccevs.org/MMO/PP/-424-/#FTP_TRP.1.3
+    ### The OS shall require use of the trusted path for all remote
+    ### administrative actions.
+
+    #######################################################
+    # 5.2.3 Class AGD: Guidance Documentation
+
+    #######################################################
+    ## Content and presentation elements
+
+    ### AGD_PRE.1.2C: https://www.niap-ccevs.org/MMO/PP/-424-/#AGD_PRE.1.2C
+    ### The preparative procedures shall describe all the steps necessary
+    ### for secure installation of the OS and for all the secure preparation
+    ### of the operational environment in accordance with the security
+    ### objectives for the operational environment as described in the ST
+    - installed_OS_is_vendor_supported
+    - installed_OS_is_FIPS_certified
+    - grub2_audit_argument
+    - grub2_audit_backlog_limit_argument
+    - service_auditd_enabled
+    # - rpm_verify_hashes  # Takes too long to complete
+    - selinux_all_devicefiles_labeled
+    - selinux_confinement_of_daemons
+    - selinux_policytype
+    - selinux_state
+    - audit_rules_immutable
+    - var_selinux_policy_name=targeted
+    - var_selinux_state=enforcing
+    - ensure_redhat_gpgkey_installed
+    - ensure_gpgcheck_globally_activated
+    - ensure_gpgcheck_never_disabled
+    - ensure_gpgcheck_local_packages
+
+    #######################################################
+    # Appendix A Optional Requirements
+
+    #######################################################
+    ## FCS_TLSC_EXT.4 TLS Client Protocol
+
+    ### FCS_TLSC_EXT.4.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_TLSC_EXT.4.1
+    ### The OS shall support mutual authentication using X.509v3 certificates
+
+    #######################################################
+    ## FDP_IFC_EXT.1 Information flow control
+
+    ### FDP_IFC_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FDP_IFC_EXT.1.1
+    ### The OS shall [selection:
+    ###     - provide an interface which allows a VPN client to protect
+    ###       all IP traffic using IPsec,
+    ###     - provide a VPN client which can protects all IP traffic
+    ###       using IPsec
+    ### ] with the exception of IP traffic required to establish the VPN connection
+    ### and [selection: signed updates directly from the OS vendor, no other
+    ### traffic]
+
+    #######################################################
+    ## FTA_TAB.1 Default TOE access banners
+
+    ### FTA_TAB.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FTA_TAB.1.1
+    ### Before establishing a user session, the OS shall display an
+    ### advisory warning message regarding unauthorized use of the OS.
+
+
+    #######################################################
+    # Appendix B Selection-Based Requirements
+
+    #######################################################
+    ## FCS_DTLS_EXT.1 DTLS Implementation
+
+    ### FCS_DTLS_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_DTLS_EXT.1.1
+    ### The OS shall implement the DTLS protocol in accordance with
+    ### [selection: DTLS 1.0 (RFC 4347), DTLS 1.2 (RFC 6347)].
+
+
+    ### FCS_DTLS_EXT.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_DTLS_EXT.1.2
+    ### The OS shall implement the requirements in TLS (FCS_TLSC_EXT.1) for the DTLS
+    ### implementation, except where variations are allowed according to DTLS
+    ### 1.2 (RFC 6347).
+
+    #######################################################
+    ## FCS_TLSC_EXT.2 TLS Client Protocol
+
+    ### FCS_TLSC_EXT.2.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_TLSC_EXT.2.1
+    ### The OS shall present the Supported Elliptical Curves Extension in the Client
+    ### Hello with the following NIST curves: [selection: secp256r1, secp384r1,
+    ### secp521r1].
+
+
+    #######################################################
+    # Appendix C Objective Requirements
+
+    #######################################################
+    ## FCS_TLSC_EXT.3 TLS Client Protocol
+
+    ### FCS_TLSC_EXT.3.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_TLSC_EXT.3.1
+    ### The OS shall present the signature_algorithms extension in the Client Hello
+    ### with the supported_signature_algorithms value containing the following hash
+    ### algorithms: [selection: SHA256, SHA384, SHA512] and no other hash algorithms.
+
+
+    #######################################################
+    ## FPT_SRP_EXT.1 Software Restriction Policies
+
+    ### FPT_SRP_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_SRP_EXT.1.1
+    ### The OS shall restrict execution to only programs which match an
+    ### administrator-specified [selection:
+    ###     - file path,
+    ###     - file digital signature,
+    ###     - version,
+    ###     - hash,
+    ###     - [assignment: other characteristics]]
+
+
+    #######################################################
+    ## FPT_W^X_EXT.1 Write XOR Execute Memory Pages
+
+    ### FPT_W^X_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_W^X_EXT.1.1
+    ### The OS shall prevent allocation of any memory region with both write
+    ### and execute permissions except for [assignment: list of exceptions]
+
+
+
+
+
+
+
+
+
+    #######################################################
+    ## Rules that need a home?
+
+    - enable_fips_mode
+    - sysctl_kernel_yama_ptrace_scope
+    - sysctl_kernel_kptr_restrict
+    - sysctl_kernel_kexec_load_disabled
+    - sysctl_kernel_dmesg_restrict
+    - grub2_slub_debug_argument
+    - grub2_page_poison_argument
+    - grub2_vsyscall_argument
+
+    - audit_rules_privileged_commands_at
+    - audit_rules_privileged_commands_crontab
+    - audit_rules_privileged_commands_mount
+    - audit_rules_privileged_commands_umount
+    - audit_rules_sysadmin_actions
+    - audit_rules_session_events
+
+    - audit_rules_privileged_commands_ssh_keysign
+    - rsyslog_cron_logging
+    - mount_option_dev_shm_nodev
+    - mount_option_dev_shm_noexec
+    - mount_option_dev_shm_nosuid
+    - package_abrt_removed
+
+    - var_system_crypto_policy=fips
+    - configure_crypto_policy
+    - configure_bind_crypto_policy
+    - configure_openssl_crypto_policy
+    - configure_libreswan_crypto_policy
+    - configure_ssh_crypto_policy
+    - configure_kerberos_crypto_policy

--- a/2019Labs/CustomSecurityContent/setup/data/ospp.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp.profile
@@ -1,3 +1,5 @@
+# This is a modified OSPP profile from v0.1.43
+
 documentation_complete: true
 
 title: 'Protection Profile for General Purpose Operating Systems'

--- a/2019Labs/CustomSecurityContent/setup/labs_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/labs_setup.yml
@@ -78,7 +78,7 @@
   - name: Clone the CaC/c Git for Lab Tracks
     git:
       repo: "{{ CACC_LOCAL }}"
-      version: 'v0.1.43'
+      version: 'v0.1.45'
       dest: "{{ LABS_ROOT }}/{{ item }}"
       force: yes
     loop:
@@ -95,47 +95,57 @@
       remote_src: yes
     when: False
 
-  - name: Introduce a typo
+  - name: "Ex. 1: Introduce a typo 1/2"
     replace:
       dest: "{{ LABS_ROOT }}/{{ TRACK_1_LABEL }}/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml"
       regexp: '(    after pam_pwquality to set minimum password length requirements.)'
       replace: '\1\n\1'
 
-  - name: Introduce a typo
+  - name: "Ex. 1: Introduce a typo 2/2"
     replace:
       dest: "{{ LABS_ROOT }}/{{ TRACK_1_LABEL }}/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml"
       regexp: '(    Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that)'
       replace: '\1\n\1'
 
-  - name: Build the content to be used in lab 2
-    shell: './build_product rhel8'
-    args:
-      chdir: "{{ LABS_ROOT }}/{{ TRACK_2_LABEL }}"
-
-  - name: Remove the lab3 tests
+  - name: "Ex. 3: Remove tests"
     file:
       path: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/tests/data/group_system/group_accounts/group_accounts-session/"
       state: absent
 
-  - name: Copy bad lab3 tests
+  - name: "Ex. 3: Copy bad tests"
     copy:
       src: "data/rule_accounts_tmout"
       dest: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/tests/data/group_system/group_accounts/group_accounts-session/"
 
-  - name: Bust the OVAL
+  - name: "Ex. 4: Remove the Ansible content from rule accounts_tmout so that the attendees can create them themselves"
+    file:
+      path: "{{ LABS_ROOT }}/{{ TRACK_4_LABEL }}/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/"
+      state: absent
+
+  - name: "Ex. 5: Bust the OVAL"
     replace:
       dest: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml"
       regexp: '(operation=")greater than or equal(")'
       replace: '\1equals\2'
 
-  - name: Update the Ansible exercise to CaC master
-    git:
-      repo: "{{ CACC_LOCAL }}"
-      version: 'master'
-      dest: "{{ LABS_ROOT }}/{{ TRACK_4_LABEL }}"
-      force: yes
+  - name: "Copy our OSPP profile to the target system"
+    copy:
+      src: "data/ospp.profile"
+      dest: "{{ LABS_ROOT }}/{{ item }}/rhel8/profiles/"
+    loop:
+      - "{{ TRACK_1_LABEL }}"
+      - "{{ TRACK_2_LABEL }}"
+      - "{{ TRACK_3_LABEL }}"
+      - "{{ TRACK_4_LABEL }}"
+      - "{{ TRACK_5_LABEL }}"
 
-  - name: Remove the Ansible content from rule accounts_tmout so that the attendees can create them themselves
-    file:
-      path: "{{ LABS_ROOT }}/{{ TRACK_4_LABEL }}/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/"
-      state: absent
+  - name: Build the content to be used in exercises
+    command: "./build_product rhel8"
+    args:
+      chdir: "{{ LABS_ROOT }}/{{ item }}"
+    loop:
+      - "{{ TRACK_1_LABEL }}"
+      - "{{ TRACK_2_LABEL }}"
+#     - "{{ TRACK_3_LABEL }}"  # This exercise creates new profile before doing anything, so there is no need to build it in advance.
+#     - "{{ TRACK_4_LABEL }}"  # This exercise creates new Ansible content before doing anything, so there is no need to build it in advance.
+      - "{{ TRACK_5_LABEL }}"

--- a/2019Labs/CustomSecurityContent/setup/system_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/system_setup.yml
@@ -6,10 +6,10 @@
   tasks:
   - name: Enable Ansible repository
     yum_repository:
-      name: ansible-2.7-rhel-8
-      file: ansible-2.7-rhel-8
-      description: Ansible 2.7 RHEL8
-      baseurl: http://download.devel.redhat.com/nightly/rhel-8/ANSIBLE/latest-ANSIBLE-2.7-RHEL-8/compose/Base/$basearch/os/
+      name: ansible-2.8-for-rhel-8-x86_64-rpms
+      file: ansible-2.8-rhel-8
+      description: "Red Hat Ansible Engine 2.8 for RHEL 8 x86_64 (RPMs)"
+      baseurl: https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.8/os
       gpgcheck: no
 
   - name: Ensure SCAP Security Guide dependencies are installed
@@ -22,7 +22,7 @@
       - openscap-scanner
       - scap-workbench
       - wget  # needed for the NIST test suite for SSG
-# - ansible  # needed for Ansible validation
+      - ansible  # needed for Ansible validation
       - gedit
       state: installed
 
@@ -48,6 +48,7 @@
       - python3-jinja2
       - python3-pytest  # needed for unit tests + coverage
       - python3-PyYAML
+      - ninja  # needed for fast builds
       state: installed
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
 


### PR DESCRIPTION
- Renamed playbooks to more intuitive `labs_setup.yml` and `system_setup.yml`.
- Added build of content to Ansible setup of labs where it is applicable.
- Updated ComplianceAsCode to 0.1.45.
- Used the ospp profile from 0.1.43, disabled the `rpm_verify_hashes` selection.
- Added Ansible repository to playbook setup (not testable so far)
- Adopted exercises wrt that the first build is already there.
- Adopted exercises wrt the new upstream version of the content.

