### PR TITLE
Ported the OSPP profile name from ospp to ospp-rhel8.

### DIFF
--- a/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab1_introduction.adoc
@@ -75,7 +75,7 @@ The HTML guides are located in the respective `build/guides` of each lab exercis
 ----
 
 In the `ComplianceAsCode` project, policies are referred to as security profiles.
-The HTML guide filenames have a `ssg-<product>-guide-<profile>.html` format, so the HTML guide for the RHEL 8 Protection Profile for General Purpose Operating Systems (OSPP profile) is `ssg-rhel8-guide-ospp.html`.
+The HTML guide filenames have a `ssg-<product>-guide-<profile>.html` format, so the HTML guide for the RHEL 8 Protection Profile for General Purpose Operating Systems (OSPP profile) is `ssg-rhel8-guide-ospp-rhel8.html`.
 
 . Now, take a look at one of the provided HTML guides in a web browser.
 .. Go back to the console of your lab VM by going to the tab that you opened of the lab environment's *power control and consoles page* in Lab 0.
@@ -92,8 +92,8 @@ image::desktopfilefolder.png[100,100]
 .. Then, navigate to the location of the exercise by double-clicking the `labs` folder, followed by double-clicking the
 `lab1_introduction`, `build`, and `guides` folders.
 .. As a last step, double-click the `ssg-rhel8-guide-ospp-rhel8.html` file to open the HTML guide for the RHEL 8 OSPP profile.
-+
-image::navigateospp.png[1000,1000]
+// +
+// image::navigateospp.png[1000,1000]
 
 . Rules are organized in a system of hierarchical groups. Take a look through this HTML guide to see the various rules of the RHEL 8 OSPP profile.
 +
@@ -237,7 +237,7 @@ Open it in the editor and search for `accounts_tmout`:
 [... lab1_introduction]$ ./build_product rhel8
 ----
 +
-After the build finishes, refresh the HTML guide either by reloading it in the browser, or by reopening `build/guides/ssg-rhel8-guide-ospp.html`.
+After the build finishes, refresh the HTML guide either by reloading it in the browser, or by reopening `build/guides/ssg-rhel8-guide-ospp-rhel8.html`.
 Expect the variable value to be updated to `600`.
 +
 .The Firefox Refresh Page button
@@ -272,7 +272,7 @@ As the `default: 600` line indicates, if you do not specify the timeout duration
 .. After you are finished looking, press `Ctrl+X` to bring up the "save and exit" option.
 If you are asked about saving any changes, you probably do not want that, so enter `n`.
 
-.. Time to review the HTML guide--when refreshing or reopening `build/guides/ssg-rhel8-guide-ospp.html`, you can clearly see the rule's timeout indeed equals 600.
+.. Time to review the HTML guide--when refreshing or reopening `build/guides/ssg-rhel8-guide-ospp-rhel8.html`, you can clearly see the rule's timeout indeed equals 600.
 
 NOTE: The set of values a variable can have is discrete--all values have to be defined in the variable file.
 Therefore, it is possible to specify `var_accounts_tmout=20_min` in the profile only after adding `20_min: 1200` to the `options:` key of the variable definition.

--- a/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab4_ansible.adoc
@@ -266,28 +266,28 @@ Check the contents of this directory:
 +
 ----
 [... lab4_ansible]$ ls build/rhel8/playbooks
-cjis  cui  hipaa  ospp  pci-dss  rht-ccp  standard
+cjis  cui  hipaa  ospp   ospp-rhel8  pci-dss  rht-ccp  standard
 ----
 +
 Note that there is a directory for each profile in the RHEL8 product.
 That is because each profile consists of a different set of rules and the rules are parametrized by variables which can have different values in each profile.
 
-. The `accounts_tmout` rule is, for example, a part of the OSPP profile, so take a peek into the `ospp` directory:
+. The `accounts_tmout` rule is, for example, a part of the OSPP profile, so take a peek into the `ospp-rhel8` directory:
 +
 ----
-[... lab4_ansible]$ ls build/rhel8/playbooks/ospp
+[... lab4_ansible]$ ls build/rhel8/playbooks/ospp-rhel8
 ----
 +
-There are many playbook files in the `ospp` directory.
+There are many playbook files in the `ospp-rhel8` directory.
 One of them is the `accounts_tmout.yml` file, which is the Ansible Playbook that contains the Ansible tasks you added in the `accounts_tmout` rule.
 
 . Open it in the text editor:
 +
 ----
-[... lab4_ansible]$ nano build/rhel8/playbooks/ospp/accounts_tmout.yml
+[... lab4_ansible]$ nano build/rhel8/playbooks/ospp-rhel8/accounts_tmout.yml
 ----
 +
-The contents of the `build/rhel8/playbooks/ospp/accounts_tmout.yml` file look like this:
+The contents of the `build/rhel8/playbooks/ospp-rhel8/accounts_tmout.yml` file look like this:
 +
 ----
 
@@ -330,7 +330,7 @@ After that, you need to replace the placeholder string, `'@@HOSTS@@'`.
 ----
 [... lab4_ansible]$ nano linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
 [... lab4_ansible]$ ./build_product rhel8
-[... lab4_ansible]$ nano build/rhel8/playbooks/ospp/accounts_tmout.yml
+[... lab4_ansible]$ nano build/rhel8/playbooks/ospp-rhel8/accounts_tmout.yml
 ----
 ====
 +
@@ -358,7 +358,7 @@ Finally, the `tasks:` section contains the Ansible task that you created.
 . Run the playbook:
 +
 ----
-[... lab4_ansible]$ ansible-playbook build/rhel8/playbooks/ospp/accounts_tmout.yml
+[... lab4_ansible]$ ansible-playbook build/rhel8/playbooks/ospp-rhel8/accounts_tmout.yml
 ----
 
 . Check if it has any effect:
@@ -375,7 +375,7 @@ The biggest advantage of using Ansible tasks in `ComplianceAsCode` is that it ge
 . Run the following command to open the HTML guide for the OSPP profile for Red Hat Enterprise Linux 8 in your Firefox web browser, or navigate to the OSPP guide the same way you have in previous exercises:
 +
 ----
-[... ~]$ firefox /home/lab-user/labs/lab4_ansible/build/guides/ssg-rhel8-guide-ospp.html
+[... ~]$ firefox /home/lab-user/labs/lab4_ansible/build/guides/ssg-rhel8-guide-ospp-rhel8.html
 ----
 
 . Check the "Set Interactive Session Timeout" rule.
@@ -405,6 +405,7 @@ rhel8-playbook-cui.yml
 rhel8-playbook-default.yml
 rhel8-playbook-hipaa.yml
 rhel8-playbook-ospp.yml
+rhel8-playbook-ospp-rhel8.yml
 rhel8-playbook-pci-dss.yml
 rhel8-playbook-rht-ccp.yml
 rhel8-playbook-standard.yml
@@ -413,7 +414,7 @@ rhel8-playbook-standard.yml
 . Check the contents of the OSPP profile playbook in your editor and verify that a task for the `accounts_tmout` rule is there among all the other tasks.
 +
 ----
-[... lab4_ansible]$ nano build/ansible/rhel8-playbook-ospp.yml
+[... lab4_ansible]$ nano build/ansible/rhel8-playbook-ospp-rhel8.yml
 ----
 +
 At this point, you have per-rule Ansible Playbooks available, as well as per-profile ones.


### PR DESCRIPTION
Also disabled the screenshot referencing the ospp guide.

This is caused by an incorrect VM setup, as the real intention is
to have no ospp-rhel8.profile, just ospp.profile with contents of ospp-rhel8.profile.

This PR should be reverted as soon as the VM setup and VMs are fixed.