### PR TITLE
Fixed upload of the training OSPP profiles.

### DIFF
--- a/2019Labs/CustomSecurityContent/setup/labs_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/labs_setup.yml
@@ -136,7 +136,7 @@
   - name: "Copy our OSPP profile to the target system (RHEL8)"
     copy:
       src: "data/ospp-rhel8.profile"
-      dest: "{{ LABS_ROOT }}/{{ item }}/rhel8/profiles/"
+      dest: "{{ LABS_ROOT }}/{{ item }}/rhel8/profiles/ospp.profile"
     loop:
       - "{{ TRACK_1_LABEL }}"
       - "{{ TRACK_2_LABEL }}"
@@ -146,7 +146,7 @@
   - name: "Copy our OSPP profile to the target system (RHEL7)"
     copy:
       src: "data/ospp-rhel7.profile"
-      dest: "{{ LABS_ROOT }}/{{ item }}/rhel8/profiles/ospp.profile"
+      dest: "{{ LABS_ROOT }}/{{ item }}/rhel7/profiles/ospp.profile"
     loop:
       - "{{ TRACK_5_LABEL }}"
 


### PR DESCRIPTION
The setup that resulted in two `ospp` and `ospp-rhel8` profiles in RHEL8 content has been fixed, and the fixed setup has been saved as blueprint `RHTE-CustomSecurity-2019-09-28.1`.

If this new blueprint is used in exercises, commits s.a. #242 need to be reverted, because there would be no misleading OSPP-rhel8 profile any more. Due to this coordination being needed, I leave it up to you guys if you want to go with current BPs and current text, or whether you want to try to squeeze the fixed BP in, and fix the documentation as well.