### PR TITLE
Fix Custom content lab5 command line typos

### DIFF
--- a/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
+++ b/2019Labs/CustomSecurityContent/documentation/lab5_oval.adoc
@@ -609,11 +609,11 @@ The value is correctly considered to be noncompliant--the timeout should be 600,
 .. After you finish looking, press `Ctrl+X` to bring up the "save and exit" option.
 If you are asked about saving any changes, you probably do not want that, so enter `n`.
 
-.. What about the `correct.pass.sh` scenario?
+.. What about the `correct_value.pass.sh` scenario?
 Open it in the editor, as well:
 +
 ----
-[... rule_accounts_tmout]$ nano correct.pass.sh
+[... rule_accounts_tmout]$ nano correct_value.pass.sh
 ----
 +
 As you can see, this one sets the `TMOUT` value to 600, which is the value defined by the profile.
@@ -660,7 +660,7 @@ fi
 [... rule_accounts_tmout]$ cd /home/lab-user/labs/lab5_oval
 [... lab5_oval]$ ./build_product rhel7
 ...
-[... lab5_oval]$ sudo tests/test_suite.py rule --container ssg_test_suite --datastream build/ssg-rhel7-ds.xml accounts_tmout
+[... lab5_oval]$ sudo python3 tests/test_suite.py rule --container ssg_test_suite --datastream build/ssg-rhel7-ds.xml accounts_tmout
 ...
 INFO - Logging into /home/lab-user/labs/lab5_oval/logs/...
 INFO - xccdf_org.ssgproject.content_rule_accounts_tmout


### PR DESCRIPTION
- Fix typo in test scenario name
- Add python3 to `test_suite.py` command