### PR TITLE
Fix typo RHEL7 -> RHEL8 in system_setup.yml

### DIFF
--- a/2019Labs/CustomSecurityContent/setup/system_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/system_setup.yml
@@ -51,7 +51,7 @@
       state: installed
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
 
-  - name: Ensure SCAP Security Guide Tests dependencies are installed (RHEL7)
+  - name: Ensure SCAP Security Guide Tests dependencies are installed (RHEL8)
     pip:
       name:
       - ansible


### PR DESCRIPTION
Fix OS release mismatch in task "Ensure SCAP Security Guide Tests dependencies are installed" between rhel7 <-> rhel8