### PR TITLE
Expanded setup script to cover Fedora as well.

### DIFF
--- a/2019Labs/CustomSecurityContent/setup/data/ospp-fedora.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp-fedora.profile
@@ -235,7 +235,7 @@ selections:
     ### FMT_MOF_EXT.1 / AC-11(a)
     ### Set Screen Lock Timeout Period to 30 Minutes or Less
     - accounts_tmout
-    - var_accounts_tmout=30_min
+    - var_accounts_tmout=10_min
 
     ### FIA_AFL.1
     ### Disable Unauthenticated Login (such as Guest Accounts)

--- a/2019Labs/CustomSecurityContent/setup/data/ospp-fedora.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp-fedora.profile
@@ -221,6 +221,7 @@ selections:
     ### FMT_MOF_EXT.1 / AC-11(a)
     ### Enable Screen Lock
     - package_tmux_installed
+    # - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay
@@ -518,7 +519,7 @@ selections:
     ### FPT_TUD_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TUD_EXT.1.1
     ### The OS shall provide the ability to check for updates
     ### to the OS software itself.
-    - security_patches_up_to_date
+    # - security_patches_up_to_date  # Not available on Fedora
 
     ### FPT_TUD_EXT.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_TUD_EXT.1.2
     ### The OS shall cryptographically verify updates to itself using
@@ -714,7 +715,7 @@ selections:
     - audit_rules_immutable
     - var_selinux_policy_name=targeted
     - var_selinux_state=enforcing
-    - ensure_redhat_gpgkey_installed
+    # - ensure_redhat_gpgkey_installed  # Not available on Fedora
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
     - ensure_gpgcheck_local_packages

--- a/2019Labs/CustomSecurityContent/setup/data/ospp-fedora.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp-fedora.profile
@@ -233,7 +233,7 @@ selections:
     - configure_tmux_lock_command
 
     ### FMT_MOF_EXT.1 / AC-11(a)
-    ### Set Screen Lock Timeout Period to 30 Minutes or Less
+    ### Set Screen Lock Timeout Period to 10 Minutes or Less
     - accounts_tmout
     - var_accounts_tmout=10_min
 

--- a/2019Labs/CustomSecurityContent/setup/data/ospp-rhel7.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp-rhel7.profile
@@ -148,9 +148,6 @@ selections:
     - audit_rules_immutable
     - audit_rules_kernel_module_loading_delete
     - audit_rules_kernel_module_loading_init
-    - audit_rules_kernel_module_loading_insmod
-    - audit_rules_kernel_module_loading_modprobe
-    - audit_rules_kernel_module_loading_rmmod
     - audit_rules_login_events_faillock
     - audit_rules_login_events_lastlog
     - audit_rules_login_events_tallylog
@@ -401,7 +398,6 @@ selections:
     - network_sniffer_disabled
     - network_ipv6_disable_rpc
     - network_ipv6_privacy_extensions
-    - dconf_use_text_backend
     - dconf_gnome_banner_enabled
     - dconf_gnome_disable_automount
     - dconf_gnome_disable_ctrlaltdel_reboot

--- a/2019Labs/CustomSecurityContent/setup/data/ospp-rhel8.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp-rhel8.profile
@@ -232,7 +232,7 @@ selections:
     - configure_tmux_lock_command
 
     ### FMT_MOF_EXT.1 / AC-11(a)
-    ### Set Screen Lock Timeout Period to 30 Minutes or Less
+    ### Set Screen Lock Timeout Period to 10 Minutes or Less
     - accounts_tmout
     - var_accounts_tmout=10_min
 

--- a/2019Labs/CustomSecurityContent/setup/data/ospp-rhel8.profile
+++ b/2019Labs/CustomSecurityContent/setup/data/ospp-rhel8.profile
@@ -234,7 +234,7 @@ selections:
     ### FMT_MOF_EXT.1 / AC-11(a)
     ### Set Screen Lock Timeout Period to 30 Minutes or Less
     - accounts_tmout
-    - var_accounts_tmout=30_min
+    - var_accounts_tmout=10_min
 
     ### FIA_AFL.1
     ### Disable Unauthenticated Login (such as Guest Accounts)

--- a/2019Labs/CustomSecurityContent/setup/labs_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/labs_setup.yml
@@ -57,20 +57,6 @@
      - id_rsa.pub
     become_user: root
 
-  - name: Build a RHEL7 podman image for testing
-    shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-rhel   .'
-    args:
-      chdir: "{{ CACC_LOCAL }}/Dockerfiles"
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
-    become_user: root
-
-  - name: Build a Fedora podman image for testing
-    shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora .'
-    args:
-      chdir: "{{ CACC_LOCAL }}/Dockerfiles"
-    when: ansible_distribution == 'Fedora'
-    become_user: root
-
   - name: Remove the lab3 tests
     file:
       path: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/content/tests/data/group_system/group_accounts/group_accounts-session/"
@@ -119,15 +105,15 @@
       regexp: '(    Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that)'
       replace: '\1\n\1'
 
-  - name: "Ex. 3: Remove tests"
+  - name: "Ex. 5: Remove tests"
     file:
-      path: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/tests/data/group_system/group_accounts/group_accounts-session/"
+      path: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests"
       state: absent
 
-  - name: "Ex. 3: Copy bad tests"
+  - name: "Ex. 5: Copy bad tests"
     copy:
-      src: "data/rule_accounts_tmout"
-      dest: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/tests/data/group_system/group_accounts/group_accounts-session/"
+      src: "data/rule_accounts_tmout/"
+      dest: "{{ LABS_ROOT }}/{{ TRACK_5_LABEL }}/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/"
 
   - name: "Ex. 4: Remove the Ansible content from rule accounts_tmout so that the attendees can create them themselves"
     file:
@@ -189,3 +175,17 @@
       chdir: "{{ LABS_ROOT }}/{{ item }}"
     loop:
       - "{{ TRACK_5_LABEL }}"
+
+  - name: Build a RHEL7 podman image for testing
+    shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-rhel   .'
+    args:
+      chdir: "{{ CACC_LOCAL }}/Dockerfiles"
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    become_user: root
+
+  - name: Build a Fedora podman image for testing
+    shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora .'
+    args:
+      chdir: "{{ CACC_LOCAL }}/Dockerfiles"
+    when: ansible_distribution == 'Fedora'
+    become_user: root

--- a/2019Labs/CustomSecurityContent/setup/labs_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/labs_setup.yml
@@ -14,8 +14,16 @@
     TRACK_5_LABEL: "lab5_oval"
     CACC_LOCAL: "/tmp/complianceAsCode"
     LABS_ROOT: "/home/lab-user/labs"
+    TARGET_PRODUCT: "rhel8"
+    CONTAINER_PRODUCT: "rhel7"
 
   tasks:
+  - name: Set variables (Fedora)
+    set_fact:
+      TARGET_PRODUCT: "fedora"
+      CONTAINER_PRODUCT: "fedora"
+    when: ansible_distribution == 'Fedora'
+
   - name: Clone the CaC/c Git repository
     git:
       repo: 'https://github.com/ComplianceAsCode/content.git'
@@ -49,14 +57,18 @@
      - id_rsa.pub
     become_user: root
 
-  - name: Build a podman image for testing
-# TODO: The RHEL image doesn't work with subscription, even if the host is subscribed.
-# TODO: Building as the root user, as port binding requires root privileges, may not be the case for RHEL8 GA podman.
+  - name: Build a RHEL7 podman image for testing
     shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-rhel   .'
-#   shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora .'
     args:
       chdir: "{{ CACC_LOCAL }}/Dockerfiles"
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    become_user: root
+
+  - name: Build a Fedora podman image for testing
+    shell: 'podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora .'
+    args:
+      chdir: "{{ CACC_LOCAL }}/Dockerfiles"
+    when: ansible_distribution == 'Fedora'
     become_user: root
 
   - name: Remove the lab3 tests
@@ -78,7 +90,7 @@
   - name: Clone the CaC/c Git for Lab Tracks
     git:
       repo: "{{ CACC_LOCAL }}"
-      version: 'v0.1.45'
+      version: 'v0.1.47'
       dest: "{{ LABS_ROOT }}/{{ item }}"
       force: yes
     loop:
@@ -133,7 +145,7 @@
       regexp: '(operation=")greater than or equal(")'
       replace: '\1equals\2'
 
-  - name: "Copy our OSPP profile to the target system (RHEL8)"
+  - name: "Copy our RHEL8 OSPP profile to the target system"
     copy:
       src: "data/ospp-rhel8.profile"
       dest: "{{ LABS_ROOT }}/{{ item }}/rhel8/profiles/ospp.profile"
@@ -143,15 +155,26 @@
       - "{{ TRACK_3_LABEL }}"
       - "{{ TRACK_4_LABEL }}"
 
-  - name: "Copy our OSPP profile to the target system (RHEL7)"
+  - name: "Copy our Fedora OSPP profile to the target system"
+    copy:
+      src: "data/ospp-fedora.profile"
+      dest: "{{ LABS_ROOT }}/{{ item }}/fedora/profiles/ospp.profile"
+    loop:
+      - "{{ TRACK_1_LABEL }}"
+      - "{{ TRACK_2_LABEL }}"
+      - "{{ TRACK_3_LABEL }}"
+      - "{{ TRACK_4_LABEL }}"
+      - "{{ TRACK_5_LABEL }}"
+
+  - name: "Copy our RHEL7 OSPP profile to the target system"
     copy:
       src: "data/ospp-rhel7.profile"
       dest: "{{ LABS_ROOT }}/{{ item }}/rhel7/profiles/ospp.profile"
     loop:
       - "{{ TRACK_5_LABEL }}"
 
-  - name: Build the RHEL8 content to be used in exercises
-    command: "./build_product rhel8"
+  - name: "Build the {{ TARGET_PRODUCT }} content to be used in exercises"
+    command: "./build_product {{ TARGET_PRODUCT }}"
     args:
       chdir: "{{ LABS_ROOT }}/{{ item }}"
     loop:
@@ -160,8 +183,8 @@
 #     - "{{ TRACK_3_LABEL }}"  # This exercise creates new profile before doing anything, so there is no need to build it in advance.
 #     - "{{ TRACK_4_LABEL }}"  # This exercise creates new Ansible content before doing anything, so there is no need to build it in advance.
 
-  - name: Build the RHEL7 content to be used in the container scanning exercise
-    command: "./build_product rhel7"
+  - name: Build the {{ CONTAINER_PRODUCT }} content to be used in the container scanning exercise
+    command: "./build_product {{ CONTAINER_PRODUCT }}"
     args:
       chdir: "{{ LABS_ROOT }}/{{ item }}"
     loop:

--- a/2019Labs/CustomSecurityContent/setup/system_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/system_setup.yml
@@ -3,13 +3,16 @@
   become: yes
   become_method: sudo
 
+  vars:
+    ANSIBLE_VERSION: "2.9"
+
   tasks:
-  - name: Enable Ansible repository
+  - name: Enable Ansible {{ ANSIBLE_VERSION }} repository
     yum_repository:
-      name: ansible-2.9-for-rhel-8-x86_64-rpms
+      name: ansible-{{ ANSIBLE_VERSION }}-for-rhel-8-x86_64-rpms
       file: redhat # To use the same file as the subscription-manager
-      description: "Red Hat Ansible Engine 2.8 for RHEL 8 x86_64 (RPMs)"
-      baseurl: https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.8/os
+      description: "Red Hat Ansible Engine {{ ANSIBLE_VERSION }} for RHEL 8 x86_64 (RPMs)"
+      baseurl: https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/{{ ANSIBLE_VERSION }}/os
       gpgcheck: no
     when: ansible_distribution == 'RedHat'  # i.e. RHEL, not Fedora
 

--- a/2019Labs/CustomSecurityContent/setup/system_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/system_setup.yml
@@ -25,6 +25,7 @@
       - wget  # needed for the NIST test suite for SSG
       - ansible  # needed for Ansible validation
       - gedit
+      - nano
       state: installed
 
   - name: Ensure SCAP Security Guide dependencies are installed (RHEL7)
@@ -43,24 +44,30 @@
       - docker
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
 
-  - name: Ensure SCAP Security Guide dependencies are installed (RHEL8, Fedora)
+  - name: Ensure that package dependencies are installed (RHEL8, Fedora)
     package:
       name:
       - python3-jinja2
       - python3-pytest  # needed for unit tests + coverage
       - python3-PyYAML
+      - python3-psutil  # needed for the later dconf setting (to tweak the Gnome session)
+      - dbus-tools  # ditto
+      - dbus-daemon  # ditto
+      - podman  # needed for tests
       state: installed
     when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'
 
-  - name: Ensure SCAP Security Guide Tests dependencies are installed (RHEL8, Fedora)
+  - name: Ensure that Fedora-specific convenience packages are installed (Fedora)
     package:
       name:
-      - podman
-    when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'
+      - qemu-guest-agent
+      - spice-vdagent
+    when: ansible_distribution == 'Fedora'
 
   - name: Ensure that lab-user exists
     user:
       name: lab-user
+      groups: wheel
       password: $6$slKF3uSy7AUr0NS3$jS23cqtNIGmj2reBpyvc0O7pXDl10tUYNDZELRcVGwMAAWeNajOQMHStLr3mYemOFv7P5vPmrsKCfUWDRMyZg1  # r3dh4t1!
       update_password: on_create
 
@@ -72,3 +79,37 @@
       regexp: '^lab-user'
       line: 'lab-user ALL=(ALL)       NOPASSWD: ALL'
       validate: visudo -cf %s
+
+  - name: Mark Gnome initial setup as done
+    become: yes
+    become_user: lab-user
+    lineinfile:
+      dest: /home/lab-user/.config/gnome-initial-setup-done
+      state: present
+      regexp: '^yes$'
+      line: 'yes'
+      create: yes
+
+  - name: Disable Gnome screen locking
+    become: yes
+    become_user: lab-user
+    dconf:
+      key: "/org/gnome/desktop/screensaver/lock-enabled"
+      value: "false"
+      state: present
+
+  - name: Disable Gnome screensaver
+    become: yes
+    become_user: lab-user
+    dconf:
+      key: "/org/gnome/desktop/session/idle-delay"
+      value: "uint32 0"
+      state: present
+
+  - name: Set up Gnome favorites
+    become: yes
+    become_user: lab-user
+    dconf:
+      key: "/org/gnome/shell/favorite-apps"
+      value: "['firefox.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'scap-workbench.desktop']"
+      state: present

--- a/2019Labs/CustomSecurityContent/setup/system_setup.yml
+++ b/2019Labs/CustomSecurityContent/setup/system_setup.yml
@@ -6,11 +6,12 @@
   tasks:
   - name: Enable Ansible repository
     yum_repository:
-      name: ansible-2.8-for-rhel-8-x86_64-rpms
+      name: ansible-2.9-for-rhel-8-x86_64-rpms
       file: redhat # To use the same file as the subscription-manager
       description: "Red Hat Ansible Engine 2.8 for RHEL 8 x86_64 (RPMs)"
       baseurl: https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.8/os
       gpgcheck: no
+    when: ansible_distribution == 'RedHat'  # i.e. RHEL, not Fedora
 
   - name: Ensure SCAP Security Guide dependencies are installed
     package:
@@ -42,23 +43,32 @@
       - docker
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
 
-  - name: Ensure SCAP Security Guide dependencies are installed (RHEL8)
+  - name: Ensure SCAP Security Guide dependencies are installed (RHEL8, Fedora)
     package:
       name:
       - python3-jinja2
       - python3-pytest  # needed for unit tests + coverage
       - python3-PyYAML
       state: installed
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'
 
-  - name: Ensure SCAP Security Guide Tests dependencies are installed (RHEL8)
-    pip:
-      name:
-      - ansible
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
-
-  - name: Ensure SCAP Security Guide Tests dependencies are installed (RHEL8)
+  - name: Ensure SCAP Security Guide Tests dependencies are installed (RHEL8, Fedora)
     package:
       name:
       - podman
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'
+
+  - name: Ensure that lab-user exists
+    user:
+      name: lab-user
+      password: $6$slKF3uSy7AUr0NS3$jS23cqtNIGmj2reBpyvc0O7pXDl10tUYNDZELRcVGwMAAWeNajOQMHStLr3mYemOFv7P5vPmrsKCfUWDRMyZg1  # r3dh4t1!
+      update_password: on_create
+
+  # Taken from https://stackoverflow.com/questions/33359404/ansible-best-practice-for-maintaining-list-of-sudoers
+  - name: Ensure that lab-user can do passwordless sudo
+    lineinfile:
+      dest: /etc/sudoers
+      state: present
+      regexp: '^lab-user'
+      line: 'lab-user ALL=(ALL)       NOPASSWD: ALL'
+      validate: visudo -cf %s


### PR DESCRIPTION
Allow setup of labs for Fedora hosts, so one can taste the labs without having to possess RHEL setup.

The RHEL8 path should be still preserved.

In order to test it, you need to have a Fedora VM - the best option is to have SSH keys set up so you can log in as a superuser, and that you have an entry in SSH config that maps the VM to `FEDORA_VM_HOSTNAME`.

Then, set your system up by running

```
ansible-playbook -i FEDORA_VM_HOSTNAME, system_setup.yml
ansible-playbook -i FEDORA_VM_HOSTNAME, labs_setup.yml
```

Pay attention at the comma after the hostname. If you connect as a passwordless sudoer, you may need to add the `-K` option to the playbook invocation and supply an arbitrary input as "sudo password".