### PR TITLE
Initial playbooks for 2020 rhel security labs

### DIFF
--- a/2020Labs/RHELSecurity/ansible/aide/aide.yml
+++ b/2020Labs/RHELSecurity/ansible/aide/aide.yml
@@ -1,0 +1,24 @@
+---
+- hosts: all
+  remote_user: root
+
+  tasks:
+
+  - name: Set authorized key taken from file for root
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ lookup('file', 'id_rsa.pub') }}"
+
+  - name: Remove aide if it's installed
+    package:
+      name: aide
+      state: absent
+
+  - name: Install required packages
+    package:
+      name:
+        - audit
+        - vim-minimal
+      state: present
+

--- a/2020Labs/RHELSecurity/ansible/audit/audit.yml
+++ b/2020Labs/RHELSecurity/ansible/audit/audit.yml
@@ -1,0 +1,31 @@
+---
+- hosts: all
+  remote_user: root
+
+  tasks:
+
+  - name: Add the user 'auditlab'
+    user:
+      name: auditlab
+
+  - name: Set authorized key taken from file for root
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ lookup('file', 'id_rsa.pub') }}"
+
+  - name: Set authorized key taken from file for adminlab
+    authorized_key:
+      user: auditlab
+      state: present
+      key: "{{ lookup('file', 'id_rsa.pub') }}"
+
+  - name: install Audit lab packages
+    package:
+      name:
+        - sed
+        - initscripts
+        - audit
+        - iputils
+        - grub2-tools
+        - vim-minimal

--- a/2020Labs/RHELSecurity/ansible/firewalld/firewalld.yml
+++ b/2020Labs/RHELSecurity/ansible/firewalld/firewalld.yml
@@ -1,0 +1,23 @@
+---
+- hosts: all
+  remote_user: root
+
+  tasks:
+
+  - name: Set authorized key taken from file for root
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ lookup('file', 'id_rsa.pub') }}"
+
+  # 3. Our lab does not have the firewall enabled by default so we will install it as root. 
+  - name: Remove firewalld lab package
+    package:
+      name: firewalld
+      state: absent
+
+#  - name: Enable and start firewalld.service
+#    service:
+#      name: firewalld
+#      enabled: yes
+#      state: started

--- a/2020Labs/RHELSecurity/ansible/gpg/gpg.yml
+++ b/2020Labs/RHELSecurity/ansible/gpg/gpg.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  remote_user: root
+
+  tasks:
+
+  - name: Set authorized key taken from file for root
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ lookup('file', 'id_rsa.pub') }}"
+
+  - name: Install required packages
+    package:
+      name:
+        - gnupg2
+      state: present
+

--- a/2020Labs/RHELSecurity/ansible/openscap/openscap.yml
+++ b/2020Labs/RHELSecurity/ansible/openscap/openscap.yml
@@ -1,0 +1,52 @@
+---
+- hosts: all
+  remote_user: root
+
+  tasks:
+  - name: Set authorized key taken from file for root
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ lookup('file', 'id_rsa.pub') }}"
+
+  - name: Install used packages
+    package:
+      name:
+      - scap-security-guide
+      - openscap-scanner
+      - scap-workbench
+      - xorg-x11-xauth
+      - firefox
+      state: present
+    tags: setup
+
+  - name: Install ansible dependency
+    package:
+      name:
+      - python3-pip
+      state: present
+    tags: setup
+
+  - name: Install ansible
+    pip:
+      name:
+      - ansible
+    tags: setup
+
+  - name: Set SSH X Forwarding
+    lineinfile:
+      create: yes
+      dest: /etc/ssh/sshd_config
+      regexp: ^X11Forwarding
+      line: "X11Forwarding yes"
+    tags: setup
+
+  - name: Remove produced artefacts
+    file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - /tmp/arf.xml
+      - /tmp/report.html
+      - /root/playbook.yml
+    tags: rewind


### PR DESCRIPTION
I've no idea where it supposed to be or how it suppose to work.

Anyway, there are 5 different playbooks in this PR which can be used to setup a standard rhel8 installation for the following labs - openscap, audit, aide, gpg, firewalld

All of them expects that there's `id_rsa.pub` public key in the current directory and so users can use `id_rsa` private key for authentication hosts using `ssh`
