### PR TITLE
Fixed a typo in the OpenSCAP Lab exercise.

### DIFF
--- a/2019Labs/RHELSecurityLab/documentation/lab1_OpenSCAP.adoc
+++ b/2019Labs/RHELSecurityLab/documentation/lab1_OpenSCAP.adoc
@@ -22,7 +22,6 @@ This section is for your reference only so you know what steps have already been
 
 .  Red Hat Enterprise Linux 8.0 is installed on the *openscap.example.com* host. We have also pre-installed several packages on the *openscap.example.com* host.
 
-. Specifically, we pre-installed *openscap-scanner*, *scap-security-guide*, and *Ansible*. Take a look at the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, don't forget to replace the *GUID* with unique lab provided *GUID*!
 . Specifically, we pre-installed *openscap-scanner*, *scap-security-guide*, and *Ansible*. Take a look at the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, don't forget to replace the *GUID* with unique lab provided *GUID*! Note that the versions of packages installed may not be up to date. However, this will not affect this lab.
 +
 [source, text]

--- a/2020Labs/RHELSecurity/documentation/lab1_OpenSCAP.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab1_OpenSCAP.adoc
@@ -22,7 +22,6 @@ This section is for your reference only so you know what steps have already been
 
 .  Red Hat Enterprise Linux 8.0 is installed on the *openscap.example.com* host. We have also pre-installed several packages on the *openscap.example.com* host.
 
-. Specifically, we pre-installed *openscap-scanner*, *scap-security-guide*, and *Ansible*. Take a look at the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, don't forget to replace the *GUID* with unique lab provided *GUID*!
 . Specifically, we pre-installed *openscap-scanner*, *scap-security-guide*, and *Ansible*. Take a look at the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, don't forget to replace the *GUID* with unique lab provided *GUID*! Note that the versions of packages installed may not be up to date. However, this will not affect this lab.
 +
 [source, text]


### PR DESCRIPTION
One bullet point was there twice.
And I am not sure whether it is a good idea to advertise that "versions of packages installed may not be up to date" as we do right now. I would say most people wouldn't notice, and our goal is to be up-to-date wrt the version of RHEL labs are based on.