### PR TITLE
Drop constrains from authorized_keys and allow root to directly login via ssh

### DIFF
--- a/2020Labs/RHELSecurity/ansible/aide/aide.yml
+++ b/2020Labs/RHELSecurity/ansible/aide/aide.yml
@@ -4,6 +4,8 @@
 
   tasks:
 
+  - import_tasks: fix-authorized_keys.yml
+
   - name: Remove aide if it's installed
     package:
       name: aide

--- a/2020Labs/RHELSecurity/ansible/aide/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/aide/fix-authorized_keys.yml
@@ -1,0 +1,1 @@
+../fix-authorized_keys.yml

--- a/2020Labs/RHELSecurity/ansible/audit/audit.yml
+++ b/2020Labs/RHELSecurity/ansible/audit/audit.yml
@@ -4,6 +4,8 @@
 
   tasks:
 
+  - import_tasks: fix-authorized_keys.yml
+
   - name: Add the user 'auditlab'
     user:
       name: auditlab

--- a/2020Labs/RHELSecurity/ansible/audit/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/audit/fix-authorized_keys.yml
@@ -1,0 +1,1 @@
+../fix-authorized_keys.yml

--- a/2020Labs/RHELSecurity/ansible/firewalld/firewalld.yml
+++ b/2020Labs/RHELSecurity/ansible/firewalld/firewalld.yml
@@ -4,6 +4,8 @@
 
   tasks:
 
+  - import_tasks: fix-authorized_keys.yml
+
   # 3. Our lab does not have the firewall enabled by default so we will install it as root. 
   - name: Remove firewalld lab package
     package:

--- a/2020Labs/RHELSecurity/ansible/firewalld/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/firewalld/fix-authorized_keys.yml
@@ -1,0 +1,1 @@
+../fix-authorized_keys.yml

--- a/2020Labs/RHELSecurity/ansible/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/fix-authorized_keys.yml
@@ -1,0 +1,5 @@
+- name: Drop constrains from /root/.ssh/authorized_keys
+  replace:
+    path: /root/.ssh/authorized_keys
+    regexp: '^.* ssh-rsa '
+    replace: 'ssh-rsa '

--- a/2020Labs/RHELSecurity/ansible/gpg/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/gpg/fix-authorized_keys.yml
@@ -1,0 +1,1 @@
+../fix-authorized_keys.yml

--- a/2020Labs/RHELSecurity/ansible/gpg/gpg.yml
+++ b/2020Labs/RHELSecurity/ansible/gpg/gpg.yml
@@ -4,6 +4,8 @@
 
   tasks:
 
+  - import_tasks: fix-authorized_keys.yml
+
   - name: Install required packages
     package:
       name:

--- a/2020Labs/RHELSecurity/ansible/ipsec/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/ipsec/fix-authorized_keys.yml
@@ -1,0 +1,1 @@
+../fix-authorized_keys.yml

--- a/2020Labs/RHELSecurity/ansible/ipsec/ipsec1.yml
+++ b/2020Labs/RHELSecurity/ansible/ipsec/ipsec1.yml
@@ -4,6 +4,8 @@
 
   tasks:
 
+  - import_tasks: fix-authorized_keys.yml
+
   - name: Remove libreswan lab package
     package:
       name: libreswan

--- a/2020Labs/RHELSecurity/ansible/openscap/fix-authorized_keys.yml
+++ b/2020Labs/RHELSecurity/ansible/openscap/fix-authorized_keys.yml
@@ -1,0 +1,1 @@
+../fix-authorized_keys.yml

--- a/2020Labs/RHELSecurity/ansible/openscap/openscap.yml
+++ b/2020Labs/RHELSecurity/ansible/openscap/openscap.yml
@@ -3,6 +3,8 @@
   become: yes
 
   tasks:
+  - import_tasks: fix-authorized_keys.yml
+
   - name: Install used packages
     package:
       name:


### PR DESCRIPTION
Default /root/.ssh/authorized_keys contains the following constrains:

~~~~
no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo 'Please login as the user \"ec2-user\" rather than the user \"root\".';echo;sleep 10" ssh-rsa AAAA... id_rsa
~~~~~

Security Lbas uses root login and X Forwarding therefore we need to drop them.