### PR TITLE
Update 2020 rhel security doc with tech writer changes

### DIFF
--- a/2020Labs/RHELSecurity/documentation/README.adoc
+++ b/2020Labs/RHELSecurity/documentation/README.adoc
@@ -1,78 +1,80 @@
-= Defend Yourself Using Built-in Red Hat Enterprise Linux Security Technologies
+:linkattrs:
 
-== [.underline]#Presenters/Lab Developers#:
-*Lucy Kerner*, Senior Principal Security Global Technical Evangelist & Strategist, Red Hat
+== Defend Yourself Using Built-in Red Hat Enterprise Linux Security Technologies
 
-*Peter Beniaris*, Manager - Solutions Architecture, Red Hat
+== Presenters/Lab Developers
+*Lucy Kerner*, Senior Principal Security Global Technical Evangelist & Strategist, Red Hat^(R)^
 
-*Lukas Vrabec*, Senior Software Engineer - RHEL Security, Red Hat
+*Peter Beniaris*, Manager--Solutions Architecture, Red Hat
 
-*Marek Haicman*, Senior Quality Engineer and Product Owner - Security Compliance, Red Hat
+*Lukas Vrabec*, Senior Software Engineer--Red Hat Enterprise Linux^(R)^ (RHEL) Security, Red Hat
 
-*Simo Sorce*, Senior Principal Software Engineer - RHEL Security, Red Hat
+*Marek Haicman*, Senior Quality Engineer and Product Owner--Security Compliance, Red Hat
 
-== [.underline]#Additional Lab Developers#:
-*Paul Wouters*, Senior Software Engineer - RHEL Security, Red Hat
+*Simo Sorce*, Senior Principal Software Engineer--RHEL Security, Red Hat
 
-*Daniel Kopecek*, Senior Software Engineer - RHEL Security, Red Hat
+== Lab Developers
+*Paul Wouters*, Senior Software Engineer--RHEL Security, Red Hat
 
-*Kirill Gliebov*, Software Engineer - RHEL Security, Red Hat
+*Daniel Kopecek*, Senior Software Engineer--RHEL Security, Red Hat
 
-*Matej Tyc*, Software Engineer and Tech Lead - Security Compliance in RHEL Security, Red Hat
+*Kirill Gliebov*, Software Engineer--RHEL Security, Red Hat
 
-*Steve Grubb*, Senior Principal Software Engineer - RHEL Security, Red Hat
+*Matej Tyc*, Software Engineer and Tech Lead--Security Compliance in RHEL Security, Red Hat
 
-*Richard Guy Briggs*, Senior Software Engineer - RHEL Security, Red Hat
+*Steve Grubb*, Senior Principal Software Engineer--RHEL Security, Red Hat
+
+*Richard Guy Briggs*, Senior Software Engineer--RHEL Security, Red Hat
+
+== Overview and Prerequisites
+In this lab, you learn how to build defense-in-depth in the operating system by implementing the key security technologies available to you in the latest version of Red Hat Enterprise Linux.
+
+In a defense-in-depth approach, you implement security at all layers to build a strong foundation to proactively defend against possible security attacks and breaches. You provide security compliance by using technologies such as OpenSCAP, Audit, Audit Intrusion Detection Environment (AIDE), session recording, and system-wide cryptographic policies. You implement physical security with technologies such as USBGuard and add network security with technologies such as firewalld, SELinux port security, and IPSec. You implement access management with Ansible^(R)^ system roles, identity management, and SELinux process isolation. You implement data security with Linux Unified Key Setup (LUKS), Network Bound Disk Encryption (NBDE), and GNU Privacy Guard (GPG).
+
+Specifically, you use OpenSCAP to scan and remediate against vulnerabilities and configuration security baselines. You also block possible attacks from vulnerabilities using SELinux and use Network Bound Disk Encryption to securely decrypt your encrypted boot volumes unattended. You learn how to deploy opportunistic IPsec to encrypt all host-to-host communication within an enterprise network and also use USBGuard to implement basic whitelisting and blacklisting to define which USB devices are and are not authorized and how a USB device may interact with your system. You also take advantage of the system-wide cryptographic policies for further security. Throughout your investigation of the security issues in your systems, you use audit logs and the web console, and you automate as much of your tasks as possible using Ansible. For example, you make automated configuration changes to your systems across multiple versions of Red Hat Enterprise Linux running in your environment using the Systems Roles feature. You also learn how to use AIDE, session recording, logging, and playback to look for abnormal behavior. In addition, you learn how to create a single sign-on environment for all of your Linux servers using Identity Management in Red Hat Enterprise Linux (IdM). Finally, you discover how to identify yourself and encrypt your communications with GPG and also learn how to use firewalld to dynamically manage firewall rules.
+
+This lab is geared toward systems administrators, cloud administrators and operators, architects, and others working on infrastructure operations management who are interested in learning how to take advantage of the built-in security technologies in Red Hat Enterprise Linux.
+
+The prerequisite for this lab include basic Linux skills gained from Red Hat Certified System Administrator (RHCSA^(R)^) or equivalent system administration skills.
+
+== Session Goals
+
+In this session, you learn how to:
+
+* Automate security compliance using OpenSCAP to scan and remediate against vulnerabilities and configuration security baselines.
+* Use SELinux to isolate running processes to mitigate against attacks.
+* Use NBDE to securely decrypt LUKS-encrypted volumes unattended.
+* Deploy opportunistic IPSec to encrypt all host-to-host communication within an enterprise network.
+* Take advantage of system-wide cryptographic policies.
+* Use USBGuard to protect against rogue USB devices and implement basic whitelisting and blacklisting to define which USB devices are authorized.
+* Take advantage of the auditing capabilities and the web console for easier centralized management.
+* Use the AIDE to detect intrusions.
+* Create a single sign-on environment for all of your Linux servers using IdM.
+* Use GPG to identify yourself and encrypt your communications.
+* Use firewalld to dynamically manage firewall rules.
+* Configure system-wide cryptographic policies and set a machine in Federal Information Processing Standards (FIPS) mode.
+* Take advantage of session recording, logging, and playback features and AIDE to look for abnormal behavior.
+* Use systems roles to make multiple automated configuration changes across different versions of Red Hat Enterprise Linux using Red Hat Ansible Automation.
 
 
-== Overview and Prerequisites:
-In this lab, you'll learn how you can build defense-in-depth in the OS by implementing the key security technologies available to you in the latest version of Red Hat Enterprise Linux.
+== Lab Environment
+Your entire lab environment is hosted online and includes Red Hat Enterprise Linux and Red Hat Ansible Automation.
 
-You will implement security at all layers, in a defense-in-depth approach, to build a strong foundation to proactively defend against possible security attacks and breaches. You will ensure security compliance by using technologies such as OpenSCAP, Audit, AIDE, session recording, and system wide crypto policies. You will implement physical security with technologies such as USBGuard and add network security with technologies such as firewalld, SELinux port security, and IPSec. You will implement access management with Ansible system roles, Identity Management, and SELinux process isolation. You will implement data security with Linux Unified Key Setup(LUKS), Network Bound Disk Encryption, and GNU Privacy Guard.
+You obtain your own unique *GUID*, which you use to access your instance of these Red Hat products for the labs.
 
-Specifically, you will use OpenSCAP to scan and remediate against vulnerabilities and configuration security baselines. You will also block possible attacks from vulnerabilities using SELinux and use Network Bound Disk Encryption to securely decrypt your encrypted boot volumes unattended. You will learn how to deploy opportunistic IPsec to encrypt all host to host communication within an enterprise network and also use USBGuard to implement basic whitelisting and blacklisting to define which USB devices are and are not authorized and how a USB device may interact with your system. You will also take advantage of the system-wide crypto policies for further security. Throughout your investigation of the security issues in your systems, you will utilize audit logs and the web console and you will automate as much of your tasks as possible using Ansible. For example, you will make automated configuration changes to your systems across multiple versions of Red Hat Enterprise Linux running in your environment using the Systems Roles feature. You will also learn how to use the Audit Intrusion Detection Environment (AIDE), session recording, logging, and playback to look for abnormal behavior. Also, you will learn how to create a single sign-on environment for all of your linux servers using Red Hat Identity Management. Finally, you will discover how to identify yourself and encrypt your communications with GNU Privacy Guard (GPG) and will also learn how to use firewalld to dynamically manage firewall rules.
-
-
-This lab is geared towards systems administrators, cloud administrators and operators, architects, and others working on infrastructure operations management who are interested in learning how to take advantage of the built-in security technologies in Red Hat Enterprise Linux.
-
-The prerequisite for this lab include basic Linux skills gained from Red Hat Certified System Administrator (RHCSA) or equivalent system administration skills.
-
-== Attendees, during this session, will learn:
-* How to automate security compliance using OpenSCAP to scan and remediate against vulnerabilities and configuration security baselines.
-* How to use SELinux to isolate running processes to mitigate against attacks
-* How to use Network Bound Disk Encryption (NBDE) to securely decrypt LUKs encrypted volumes unattended
-* How to deploy opportunistic IPsec to encrypt all host to host communication within an enterprise network
-* How to take advantage of system-wide crypto policies
-* How to use USBGuard to protect against rogue USB devices and implement basic whitelisting and blacklisting to define which USB devices are authorized.
-* How to take advantage of the auditing capabilities and the web console for easier centralized Management.
-* How to use the Audit Intrusion Detection Environment (AIDE)
-* How to create a single sign-on environment for all of your Linux servers using Red Hat Identity Management.
-* How to use GNU Privacy Guard (GPG) to identify yourself and encrypt your communications.
-* How to use firewalld to dynamically manage firewall rules.
-* How to configure system-wide crypto policies and set a machine in Federal Information Processing Standards(FIPS) mode.
-* How to take advantage of session recording, logging, and playback features and AIDE to look for abnormal behavior.
-* How to use systems roles to make multiple automated configuration changes across different versions of Red Hat Enterprise Linux using Red Hat Ansible Automation.
-
-
-== Lab Environment:
-Your entire lab environment is hosted online and includes: Red Hat Enterprise Linux and Red Hat Ansible Automation.
-
-You will each be given your own unique *GUID*, which you will use to access your own instance of these Red Hat products for your lab exercises.
-
-Each lab exercise is independent from each other, so feel free to do the lab exercises in whatever order you'd like.
-
+Each lab is independent from the others and it is not necessary to perform them sequentially.
 
 == Table of Contents
-* link:lab0_setup-workshops.adoc[Lab 0: Setup steps]
-* link:lab1_OpenSCAP.adoc[Lab 1: OpenSCAP]
-* link:lab2_SELinux.adoc[Lab 2: SELinux]
-* link:lab3_NBDE.adoc[Lab 3: Network Bound Disk Encryption (NBDE)]
-* link:lab4_IPsec.adoc[Lab 4: IPSec]
-* link:lab5_USBGuard.adoc[Lab 5: USBGuard]
-* link:lab6_Audit.adoc[Lab 6: Audit]
-* link:lab7_AIDE.adoc[Lab 7: Advanced Intrusion Detection Environment (AIDE)]
-* link:lab8_IdM.adoc[Lab 8: Identity Management (IdM)]
-* link:lab9_GPG.adoc[Lab 9: GNU Privacy Guard (GPG)]
-* link:lab10_firewalld.adoc[Lab 10: Firewalld]
-* link:lab11_cryptopolicies.adoc[Lab 11: Crypto Policies]
-* link:lab12_SessionRecording.adoc[Lab 12: Session Recording]
+* link:lab0_setup-workshops.adoc[Lab 0: Setup Steps^]
+* link:lab1_OpenSCAP.adoc[Lab 1: OpenSCAP^]
+* link:lab2_SELinux.adoc[Lab 2: SELinux^]
+* link:lab3_NBDE.adoc[Lab 3: Network Bound Disk Encryption (NBDE)^]
+* link:lab4_IPsec.adoc[Lab 4: IPSec^]
+* link:lab5_USBGuard.adoc[Lab 5: USBGuard^]
+* link:lab6_Audit.adoc[Lab 6: Audit^]
+* link:lab7_AIDE.adoc[Lab 7: Advanced Intrusion Detection Environment (AIDE)^]
+* link:lab8_IdM.adoc[Lab 8: Identity Management (IdM)^]
+* link:lab9_GPG.adoc[Lab 9: GNU Privacy Guard (GPG)^]
+* link:lab10_firewalld.adoc[Lab 10: Firewalld^]
+* link:lab11_cryptopolicies.adoc[Lab 11: Crypto Policies^]
+* link:lab12_SessionRecording.adoc[Lab 12: Session Recording^]

--- a/2020Labs/RHELSecurity/documentation/guidgrabber.adoc
+++ b/2020Labs/RHELSecurity/documentation/guidgrabber.adoc
@@ -1,20 +1,37 @@
-= Obtaining your GUID to access your dedicated lab environment
+:toc2:
 
-This document explains how to obtain your unique GUID.  This GUID will be used to access your dedicated lab environment.
+== Obtaining GUID to Access Dedicated Lab Environment Lab
 
-. Begin by going to https://bit.ly/2N5cEe5
+This document explains how to obtain your unique GUID that is used to access your dedicated lab environment.
+
+:numbered:
+
+== Obtaining Your GUID
+. Go to link:https://bit.ly/2N5cEe5[https://bit.ly/2N5cEe56^]:
 +
 image:images/gg1.png[GuidGrabber Landing Page]
 
-. From this page select the proper *Lab Code* for the current lab.  The *Lab Code* for this lab is *RHELSecurityLab*.  The full name of this lab is *Red Hat Enterprise Linux Security Technologies Lab*.
+. From this page, select the proper *Lab Code* for the current lab, which is *RHELSecurityLab*.
++
+The full name of this lab is *Red Hat Enterprise Linux Security Technologies Lab*.
 
-. Enter the *Activation Key*. The *Activation Key* for this lab is *security*.
+. For the *Activation Key*, enter *security*.
 
 . Click *Next*.
++
+The resulting page displays your lab's GUID and other useful information about your lab environment.
++
+You use your GUID for all of the lab exercises, so make sure to note your unique GUID.
 
-. The resulting page will display your lab's GUID and other useful information about your lab environment. You will use your GUID for all the lab exercises, so take note of your unique GUID.
-
-. When you are completely done with your lab environment, please click *Reset Workstation* so that you can move on to the next lab.  If you fail to do this, you will be locked into the GUID from the previous lab.
+. When you have completed all of the exercises in a lab, click *Reset Workstation* so that you can move on to the next lab.
++
+[IMPORTANT]
+====
+If you fail to do this, you will be locked into the GUID from the previous lab.
+====
 +
 [NOTE]
-Clicking *Reset Workstation* will not stop or delete the lab environment.
+====
+Clicking *Reset Workstation* does not stop or delete the lab environment.
+====
+

--- a/2020Labs/RHELSecurity/documentation/lab10_firewalld.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab10_firewalld.adoc
@@ -1,48 +1,48 @@
+:toc2:
+:linkattrs:
+
 = Lab 10: Firewalld
 
-*Lab Length: Short (~10 mins)*
+.*Lab Length*
+* Short (~10 mins)
 
-== Goal of Lab
-In this lab exercise, we will learn how to use firewalld to dynamically manage firewall rules.
+.*Goal*
+* Learn how to use `firewalld` to dynamically manage firewall rules
 
-== Introduction
-The firewalld daemon provides a dynamically managed firewall with support for network “zones” to assign a level of trust to a network and its associated connections and interfaces. It has support for IPv4 and IPv6 firewall settings. It supports Ethernet bridges and IP set and has a separation of runtime and permanent configuration options. It also has an interface for services or applications to add firewall rules directly. The complete communication with firewalld is done using D-Bus.
+== 10.1: Introduction
 
-You can get more granular by using the rich syntax language associated with the complex rules if necessary.  Also, you can have your applications use the direct interface as well.  This is rarely the case, but necessary to point out for those who take advantage of the granularity previously associated with iptables.
+The `firewalld` daemon provides a dynamically managed firewall with support for network _zones_ to assign a level of trust to a network and its associated connections and interfaces. It has support for IPv4 and IPv6 firewall settings. It supports Ethernet bridges and IP sets. It has a separation of runtime and permanent configuration options. It also has an interface for services or applications to add firewall rules directly. The complete communication with `firewalld` is done using D-Bus.
 
-=== Architecture
-When assessing the architecture, things to note are as follows:
+You can get more granular control, if necessary, by using the rich syntax language associated with the complex rules. You also can have your applications use the direct interface. While this is rarely needed, those who require the granularity previously associated with iptables are likely to find it useful.
 
-* The netfiler kernel packet filter has not changed
-* The service layer has changed and allows for dynamic updates
-* The user interface has changed and allows for xml configuration
+.Architecture
+When assessing the architecture, be sure to note the following:
 
-*Firewalld Interfaces*
+* The `netfilter` kernel packet filter has not changed.
+* The service layer has changed and allows for dynamic updates.
+* The user interface has changed and allows for xml configuration.
 
-The firewalld daemon allows for configuration via a command line interface, direct interface, or complex rules.  The direct interface passes rules directly to the firewall and is designed for applications that need to add firewall rules during runtime.  This method is not intended for end users, so you should use this with caution.  Complex rules use a rich language designed to be easier than direct interface for complex firewall rules that cannot be accomodated by the command line interface.  That said, the command line interface should be able to handle most, if not all, of your firewall rules and will be the focus of this lab exercise.  The firewall can also include multiple zones attached to different network interfaces, but we have a simple setup with one network interface and will confgure our default zone.
+.Firewalld Interfaces
+The `firewalld` daemon allows for configuration via a command line interface, direct interface, or complex rules. The direct interface passes rules directly to the firewall and is designed for applications that need to add firewall rules during runtime. This method is not intended for end users, so be sure to use this with caution. Complex rules use a rich language designed to be easier than the direct interface for complex firewall rules that cannot be accommodated by the command line interface. That said, the command line interface is able to handle most, if not all, of the firewall rules you are likely to need, and it is the focus of this lab. The firewall can also include multiple zones attached to different network interfaces, but in this lab you have a simple setup with one network interface and configure your default zone.
 
-== Lab 10.1 Verifying that the Firewall is Running
-The firewall is enabled by default, but we can check for that a couple of ways by running the following commands.
+== 10.2: Verifying that the Firewall Is Running
+The firewall is enabled by default, but you can check this in a couple of ways by running the following commands.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *servera.example.com* host as *root*.
+. Log in to the *servera.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@servera.example.com
 ----
 
-. Our lab does not have the firewall enabled by default so we will install it as root. Then, we'll enable and start the the firewalld service. Finally on this step, we'll confirm that the firewalld service is both active and enabled.
+. The lab does not have the firewall enabled by default, so you install it as *root*, enable and start the `firewalld` service, and confirm that the service is both active and enabled:
 +
-[source]
 ----
-
 [root@servera ~]# yum install -y firewalld
 [root@servera ~]# systemctl enable firewalld.service
 [root@servera ~]# systemctl start firewalld.service
@@ -51,59 +51,85 @@ active
 [root@servera ~]# systemctl is-enabled firewalld.service
 enabled
 ----
-. After installing firewalld, you can always check to see if it is enabled at any time by running the previous two commands, of by running:
-+
-[source]
-[root@servera ~]# systemctl status firewalld.service
 
-. If your firewalld service is not active and enabled, run the following commands:
+. After installing `firewalld`, run the previous two commands to verify that it is enabled, or run:
 +
-[source]
+----
+[root@servera ~]# systemctl status firewalld.service
+----
++
+You can do this at any time.
+
+. If your `firewalld` service is not active and enabled, run the following commands:
++
+----
 [root@servera ~]# systemctl enable firewalld.service
 [root@servera ~]# systemctl start firewalld.service
+----
 
-== Lab 10.2 Listing Firewall Rules
-. The firewall-cmd has several list options that you can view by running the following command:
-+
-[source]
+== 10.3: Listing Firewall Rules
+
+The `firewall-cmd` utility has several list options that you can view by running the following command:
+
+----
 [root@servera ~]# firewall-cmd --help | grep "\--list-"
+----
 
-. We are going to select the --list-all option and view the current firewall rules:
+. Select the `--list-all` option and view the current firewall rules:
 +
-[source]
+----
 [root@servera ~]# firewall-cmd --list-all
-
-Without specifying a zone, we are attached to the default zone, which is public.  The output lists the network interface the zone is managing, and lists active services, such as ssh.  Optionally, you can try experimenting with some of the other list commands.
-
-== Lab 10.3 Enabling a Port
-In this exercise, we are going to enable a specific port.  Remembering that the firewall is now dynamic. As a result, we have to account for runtime changes as well as those that survive a reload or a server reboot.
-
-. Let’s take a well known port and enable it.  To see a list of the commands you can use run the following:
-
+----
 +
-[source]
+Without specifying a zone, you are attached to the default zone, which is public. The output lists the network interface that the zone is managing, and lists active services, such as SSH.
+
+. Optionally, try experimenting with some of the other list commands.
+
+== 10.4: Enabling a Port
+In this section, you enable a specific port. Remember that the firewall is now dynamic, and as a result, you must account for runtime changes as well as those that survive a reload or a server reboot.
+
+. Take a well-known port and enable it.
++
+[TIP]
+====
+To see a list of the commands you can use, run the following:
+
+----
 [root@servera ~]# firewall-cmd --help | grep "\--add-"
+----
+====
 
-. We will use the --add-port command, and note that it requires both a port and a protocol.  This example uses well known port 443, which is used for https traffic.
+. Use the `--add-port` command, and note that it requires both a port and a protocol:
 +
-[source]
+----
 [root@servera ~]# firewall-cmd --add-port=443/tcp
 success
 [root@servera ~]# firewall-cmd --list-ports
 443/tcp
-
-. What we have done here is dynamically add the port to the firewall at runtime.  By doing this, we do not have to reload the firewall and disconnect existing sessions.  The caveat here is that a reload of the firewall will erase this rule.  To demonstrate this, let’s reload the firewall and list the ports:
+----
 +
-[source]
+This example uses well-known port 443, which is used for HTTPS traffic.
++
+You dynamically added the port to the firewall at runtime. By doing this, you do not have to reload the firewall and disconnect existing sessions. The caveat is that a reload of the firewall erases this rule.
+
+. Reload the firewall and list the ports to demonstrate this:
++
+----
 [root@servera ~]# firewall-cmd --reload
 success
 [root@servera ~]# firewall-cmd --list-ports
+----
 
-. You can handle this by running the following commands:
+. You can make the changes permanent so that they survive a reboot by running the following command:
 +
 ----
 [root@servera ~]# firewall-cmd --add-port=443/tcp --permanent
 success
+----
+
+. Verify that the changes survive a reload of the firewall:
++
+----
 [root@servera ~]# firewall-cmd --list-ports
 
 [root@servera ~]# firewall-cmd --reload
@@ -111,48 +137,61 @@ success
 [root@servera ~]# firewall-cmd --list-ports
 443/tcp
 ----
-
-. Note that this time it did survive the reload.  Another way to make runtime rules permanent is to add them to the firewall and then run the following command:
 +
-[source]
+Note that this time it did survive the reload.
+
+. Alternatively, use the following command to make the current rules permanent:
++
+----
 [root@servera ~]# firewall-cmd --runtime-to-permanent
 success
+----
 
-. You can remove this rule by running the following command:
+. Remove this rule and reload:
 +
-[source]
+----
 [root@servera ~]# firewall-cmd --remove-port=443/tcp --permanent
 success
 [root@servera ~]# firewall-cmd --reload
 success
+----
 
-== Lab 10.4 Enabling a Service
+== 10.5: Enabling a Service
 
-. The firewall ships with pre-configured services that can be used to enable groups of ports in the form of xml files located at: /usr/lib/firewalld/services/.  Let’s take a look at these services by performing a directory listing, followed by a firewalld-cmd command to list available services as they are presented to the firewall:
+The firewall ships with services already configured for you that can be used to enable groups of ports in the form of XML files located at `/usr/lib/firewalld/services/`.
 
+. Take a look at these services by performing a directory listing, followed by a `firewalld-cmd` command to list available services as they are presented to the firewall:
 +
-[source]
+----
 [root@servera ~]# ls /usr/lib/firewalld/services/
 [root@servera ~]# firewall-cmd --get-services
-
-. Note that the services presented to the firewall match the xml files in the directory.  Before we start this exercise, let's take a look at one of the files.  For this exercise, let’s look at the dns.xml file:
+----
 +
-[source]
+Note that the services presented to the firewall match the XML files in the directory.
+
+. Before you continue this section, examine one of the files--in this case, the `dns.xml` file:
++
+----
 [root@servera ~]# cat /usr/lib/firewalld/services/dns.xml
-
-. Note that this file enable port 53 for protocols tcp and udp.  Remember this for the next exercise when we develop a custom service.  For now, let’s enable this service on our firewall:
+----
 +
-[source]
+Note that this file enables port 53 for the TCP and UDP protocols. Remember this for the next section when you develop a custom service.
+
+. Enable this service on your firewall:
++
+----
 [root@servera ~]# firewall-cmd --add-service=dns --permanent
 success
 [root@servera ~]# firewall-cmd --reload
 success
 [root@servera ~]# firewall-cmd --list-services
 cockpit ssh dhcpv6-client dns
-
-. You can remove this rule by running the following command:
+----
 +
-[source]
+[TIP]
+====
+You can remove this rule by running the following:
+
 ----
 [root@servera ~]# firewall-cmd --remove-service=dns --permanent
 success
@@ -160,18 +199,33 @@ success
 success
 [root@servera ~]# firewall-cmd --list-services
 ----
+====
 
-== Lab 10.5 Enabling a Custom Service
-. While Red Hat Enterprise Linux comes with many pre-configured service files, you may want to create your own service file tailored for the needs of a specific application.  In this next example, we will create a file that captures all of the ports and protocols required for Red Hat Identity Manager (IdM).  A full deployment of IdM uses LDAP, Kerberos, and BIND so there are several ports.  The service files that comes pre-configured are located at /usr/lib/firewalld/service, and you should never alter these files.  Custom files reside at /etc/firewalld/services/.  The easiest way to start would be to copy a file from the default location to the custom location and then alter it to suit your needs.  For our IdM example, copy an existing file:
+== 10.6: Enabling a Custom Service
+While Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL) comes with many preconfigured service files, you may want to create your own service file tailored for the needs of a specific application. In this section, you create a file that captures all of the ports and protocols required for Identity Management in Red Hat Enterprise Linux (also known as IdM). A full deployment of IdM uses LDAP, Kerberos, and BIND, which require several ports to be accessible.
+
+[WARNING]
+====
+The service files that come preconfigured are located at `/usr/lib/firewalld/service`, and you should never alter these files.
+====
+
+Custom files reside at `/etc/firewalld/services/`. The easiest way to start is to copy a file from the default location to the custom location and then alter it to suit your needs.
+
+. For the identity management example, copy an existing file:
 +
-[source]
+----
 [root@servera ~]# cp /usr/lib/firewalld/services/dns.xml /etc/firewalld/services/idm.xml
+----
 
-. Next, edit the idm.xml file to look like the following:
+. Open the `/etc/firewalld/services/idm.xml` file in vi:
 +
-[source]
+----
 [root@servera ~]# vi /etc/firewalld/services/idm.xml
-[root@servera ~]# cat /etc/firewalld/services/idm.xml
+----
+
+. Change the contents to:
++
+----
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>IdM</short>
@@ -188,36 +242,43 @@ success
   <port protocol="udp" port="464"/>
   <port protocol="udp" port="123"/>
 </service>
-
-. When a server boots, or when you reload the firewall, the firewalld daemon will look at the custom and default directories and load the services.  Services defined in the custom directory take precedence over those in the default if the names of the files match.  Now we will reload our firewall and look to see which services are available.
+----
 +
-[source]
+When a server boots, or when you reload the firewall, the `firewalld` daemon looks at the custom and default directories and loads the services. Services defined in the custom directory take precedence over those in the default if the names of the files match.
+
+. Reload your firewall and look to see which services are available:
++
+----
 [root@servera services]# firewall-cmd --reload
 success
 [root@servera services]# firewall-cmd --get-services
+----
 
-. Look through the output generated by the last command and you will find “idm”, so we can now use it as follows:
+. Examine the output generated by the last command to find the `idm` service so you can now use it as follows:
 +
-[source]
+----
 [root@servera services]# firewall-cmd --add-service=idm --permanent
 success
 [root@servera services]# firewall-cmd --reload
 success
 [root@servera services]# firewall-cmd --list-services
 cockpit ssh dhcpv6-client idm
+----
 
-. You can remove this rule by running the following command:
+. Remove this rule, reload, and list the services to see that the `idm` service is removed:
 +
-[source]
+----
 [root@servera ~]# firewall-cmd --remove-service=idm --permanent
 success
 [root@servera ~]# firewall-cmd --reload
 success
 [root@servera ~]# firewall-cmd --list-services
+----
 +
-You will now see that the *idm* service has been removed successfully.
+Note that the `idm` service was removed successfully.
 
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ]| link:lab11_cryptopolicies.adoc[ Lab 11: Crypto Policies ]
+link:README.adoc#table-of-contents[Table of Contents^]| link:lab11_cryptopolicies.adoc[Lab 11: Crypto Policies^]
+

--- a/2020Labs/RHELSecurity/documentation/lab11_cryptopolicies.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab11_cryptopolicies.adoc
@@ -1,43 +1,46 @@
 
+:toc2:
+:linkattrs:
+
 = Lab 11: Crypto Policies
 
-*Lab Length: Short (~10 mins)*
+.*Lab Length*
+* Short (~10 mins)
 
-== Goal of Lab
-The goal of this lab is to use the new Crypto Policies tools to have a consistent security configuration across all cryptographic libraries in the system. The lab will also show how to configure the system so that it is FIPS compliant using the new simplified workflow in Red Hat Enterprise Linux 8.
+.*Goals*
+* Use the new crypto policies tools in Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL) 8 to have a consistent security configuration across all cryptographic libraries in the system
+* Configure the system so that it is FIPS-compliant using the new simplified workflow in Red Hat Enterprise Linux 8
 
-== Introduction
-The idea behind System-wide Crypto Policies is to give Administrator a simple interface to change the security level of a system, so that all cryptographic libraries follow the same set of rules and enable or disable the same set of cryptographic primitives and protocols.
+== 11.1: Introduction
 
-In the past each application required individual configuration changes to be performed on multiple different configuration files to have the system configured so that it consistently used the same cryptographic primitives across all programs. This process was difficult to maintain and operate.
+The idea behind system-wide crypto policies is to give the administrator a simple interface to change the security level of a system, so that all cryptographic libraries follow the same set of rules and enable or disable the same set of cryptographic primitives and protocols.
 
-With the introduction of crypto policies we have made it much simpler to set a default policy for all applications. The policy can still be overriden at the application level if exceptions are desired.
+In the past, each application required individual configuration changes to be performed on multiple different configuration files to have the system configured so that it consistently used the same cryptographic primitives across all programs. This process was difficult to maintain and operate.
 
-== Pre-Configured Items
-The machines have been pre-configured to use a Root CA certificate and individual X509 certificates for the Servers used for testing. The Root CA certificate has been imported in the system trust store so all applications can trust the test certificates used by the servers in the exercise.
+With the introduction of crypto policies, Red Hat has made it much simpler to set a default policy for all applications. The policy can still be overridden at the application level if exceptions are desired.
 
-== Lab 11.1 Connecting to a Web Server using TLS 1.1
-TLS 1.1 is disabled in RHEL 8 default security policy, so connecting to a TLS 1.1 server will result in an error by client tools.
-In this exercise we will explore how to enable the system to connect to legacy systems that are limited to use only TLS 1.0 or TLS 1.1 protocols.
-We will use two tools, `curl` and `wget`, as they use two different cryptographic libraries (openSSL and GnuTLS respectively), to show the crypto policy setting work across application and libraries.
+=== 11.1.1: Machine Configurations
+The machines are already configured to use a Root CA certificate and individual X.509 certificates for the servers used for testing. The Root CA certificate was imported into the system trust store, so all applications can trust the test certificates used by the servers in the exercise.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab’s GUID*. Use the password *r3dh4t1!*
+== 11.2: Connecting to a Web Server Using TLS 1.1
+Transport Layer Security (TLS) 1.1 is disabled in the default security policy of RHEL 8, so connecting to a TLS 1.1 server using client tools results in an error.
+In this section, you explore how to enable the system to connect to legacy systems that are limited to using only TLS 1.0 or TLS 1.1 protocols.
+You use two tools, `curl` and `wget`, because they use two different cryptographic libraries (openSSL and GnuTLS, respectively) to show that the cryptographic policy settings work across applications and libraries.
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *crypto.example.com* host as *root*.
+. Log in to the *crypto.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@crypto.example.com
 ----
 
-. Try to connect to the web server https://crypto2-tls11.example.com:1443 and verify that the connection is refused
+. Try to connect to the link:https://crypto2-tls11.example.com:1443[https://crypto2-tls11.example.com:1443^] web server and verify that the connection is refused:
 +
-[source]
 ----
 [root@crypto ~]# curl https://crypto2-tls11.example.com:1443
 curl: (35) error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version
@@ -51,17 +54,15 @@ GnuTLS: received alert [70]: Error in protocol version
 Unable to establish SSL connection.
 ----
 
-. Now change the system policy to allow legacy protocols
+. Change the system policy to allow legacy protocols:
 +
-[source]
 ----
 [root@crypto ~]# update-crypto-policies --set LEGACY
 Setting system policy to LEGACY
 ----
 
-. Try again with curl and wget, the default page returns the simple text *WORKS!*
+. Try again with `curl` and `wget`, and note that the default page returns the simple text `WORKS!`:
 +
-[source]
 ----
 [root@crypto ~]# curl https://crypto2-tls11.example.com:1443
 WORKS!
@@ -69,28 +70,25 @@ WORKS!
 WORKS!
 ----
 
-== Lab 11.2 Connecting to a Web Server using a SHA-1 Certificate
-SHA-1 Certificates are still enabled in RHEL 8 default security policy for compatibility reasons.
-In this exercise we will explore how to change the system to the FUTURE policy which disables SHA-1 signatures.
-We will use two tools, curl and wget, as they use two different cryptographic libraries (openSSL and GnuTLS respectively), to show the crypto policy setting work across application and libraries.
+== 11.3: Connecting to a Web Server Using a SHA-1 Certificate
+SHA-1 certificates are still enabled in the default security policy of RHEL 8 for compatibility reasons.
+In this section, you explore how to change the system to the `FUTURE` policy, which disables SHA-1 signatures.
+You use two tools, `curl` and `wget`, because they use two different cryptographic libraries (openSSL and GnuTLS, respectively), to show that the cryptographic policy settings work across applications and libraries.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab’s GUID*. Use the password *r3dh4t1!*
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *crypto.example.com* host as *root*.
+. Log in to the *crypto.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@crypto.example.com
 ----
 
-. Try to connect to the web server https://crypto2-sha1.example.com:2443 and verify that the connection is accepted
+. Try to connect to the link:https://crypto2-sha1.example.com:2443[https://crypto2-sha1.example.com:2443^] web server and verify that the connection is accepted:
 +
-[source]
 ----
 [root@crypto ~]# curl https://crypto2-sha1.example.com:2443
 WORKS!
@@ -98,17 +96,15 @@ WORKS!
 WORKS!
 ----
 
-. Now change the system policy to disable SHA-1
+. Now change the system policy to disable SHA-1:
 +
-[source]
 ----
 [root@crypto ~]# update-crypto-policies --set FUTURE
 Setting system policy to FUTURE
 ----
 
-. Try again with curl and wget, and see that the connection is refused!
+. Try again to connect with `curl` and `wget`, and see that the connection is refused:
 +
-[source]
 ----
 [root@crypto ~]# curl https://crypto2-sha1.example.com:2443
 curl: (60) SSL certificate problem: EE certificate key too weak
@@ -121,26 +117,25 @@ ERROR: The certificate of 'crypto2-sha1.example.com' is not trusted.
 ERROR: The certificate of 'crypto2-sha1.example.com' was signed using an insecure algorithm.
 ----
 
-== Lab 11.3 Switching the system into FIPS mode
+== 11.4: Switching the System into FIPS mode
 When a system is configured to work in FIPS mode, only a restricted set of approved cryptographic algorithms is permitted.
-In this exercise we will learn how to put a system into FIPS mode and we'll test that specific algorithms are disabled in this mode.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab’s GUID*. Use the password *r3dh4t1!*
+In this section, you learn how to put a system into FIPS mode, then you test that specific algorithms are disabled in this mode.
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *crypto.example.com* host as *root*.
+. Log in to the *crypto.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@crypto.example.com
 ----
 
-. Let's change the system configuration to run in FIPS mode.
-[source]
+. Change the system configuration to run in FIPS mode:
++
 ----
 [root@crypto ~]# fips-mode-setup --enable
 Setting system policy to FIPS
@@ -151,32 +146,29 @@ FIPS mode will be enabled.
 Please reboot the system for the setting to take effect.
 ----
 
-. Now let's reboot the system to activate FIPS mode.
+. Reboot the system to activate FIPS mode:
 +
-[source]
 ----
 [root@crypto ~]# reboot
 Connection to crypto.example.com closed by remote host.
 Connection to crypto.example.com closed.
 ----
 
-. Log again into the *crypto.example.com* host as *root* after reboot (retry multiple times if the command fails).
+. Log in again to the *crypto.example.com* host as *root* after reboot (retry multiple times if the command fails):
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@crypto.example.com
 ----
 
-. Let's check that the system is in FIPS mode.
-[source]
+. Verify that the system is in FIPS mode:
++
 ----
 [root@crypto ~]# fips-mode-setup --check
 FIPS mode is enabled.
 ----
 
-. Let's check that SHA-1 signed certificates are disabled in FIPS mode.
+. Verify that SHA-1 signed certificates are disabled in FIPS mode:
 +
-[source]
 ----
 [root@crypto ~]# curl https://crypto2-sha1.example.com:2443
 curl: (60) SSL certificate problem: EE certificate key too weak
@@ -189,9 +181,8 @@ ERROR: The certificate of 'crypto2-sha1.example.com' is not trusted.
 ERROR: The certificate of 'crypto2-sha1.example.com' was signed using an insecure algorithm.
 ----
 
-. Let's also check that unapproved Elliptic Curves are not accepted.
+. Verify that unapproved elliptic curves are not accepted:
 +
-[source]
 ----
 [root@crypto ~]# wget https://crypto2-ed25519.example.com:3443
 --2019-03-06 19:35:20--  https://crypto2-ed25519.example.com:3443/
@@ -202,9 +193,8 @@ GnuTLS: received alert [40]: Handshake failed
 Unable to establish SSL connection.
 ----
 
-. Now let's disable FIPS and return the system to the default policy
+. Disable FIPS and return the system to the default policy:
 +
-[source]
 ----
 [root@crypto ~]# fips-mode-setup --disable
 Setting system policy to DEFAULT
@@ -215,15 +205,15 @@ FIPS mode will be disabled.
 Please reboot the system for the setting to take effect.
 ----
 
-. Let's check that certificates using Ed25519 are accepted again.
+. Verify that certificates using Ed25519 are accepted again:
 +
-[source]
 ----
 [root@crypto ~]# wget -q -O - https://crypto2-ed25519.example.com:3443
 WORKS!
 ----
-NOTE: This step works even without a reboot because the wget is a command line binary and not a long term running process. Reboot is recommended to make sure all resident services are restarted and re-read their configuration (including the libraries they instantiate).
+NOTE: This step works even without a reboot because `wget` is a command-line binary and not a long-term running process. A reboot is recommended to make sure that all of the resident services are restarted and their configuration re-read (including the libraries that they instantiate).
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab12_SessionRecording.adoc[ Lab 12: Session Recording ]
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab12_SessionRecording.adoc[Lab 12: Session Recording^]
+

--- a/2020Labs/RHELSecurity/documentation/lab12_SessionRecording.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab12_SessionRecording.adoc
@@ -1,208 +1,240 @@
 
+:toc2:
+:linkattrs:
+
 = Lab 12: Session Recording
 
-*Lab Length: Medium/Average (~15 mins)*
+.*Lab Length*
+* Medium/Average (~15 mins)
 
-== Goal of Lab
-The goal of this lab is to use Session Recording to help log and audit user's terminal sessions and correlate them with system logs.
+.*Goal*
+* Use Session Recording to help log and audit users' terminal sessions and correlate them with system logs
 
-* You will need to install required software. Required packages are tlog & cockpit-session-recording.
-* You will configure it to record terminal activity for specific users.
-* You will wear a hat of third-party contractor who will break something on your system.
-* You will wear a hat of a system administrator to find out what has happened to your system.
+== 12.1: Introduction
 
-== Introduction
-Terminal Session Recording project aims to log user's terminal sessions for purposes of audit, security and monitoring. It provides interface in Cockpit to analyze these recordings and correlate them with system logs. This provides a whole picture of activity which has happened.
+The Terminal Session Recording project aims to log users' terminal sessions for the purposes of audit, security, and monitoring. It provides an interface in Cockpit to analyze these recordings and correlate them with system logs. This provides a comprehensive picture of the activity that took place.
 
-=== tlog
-Tlog records terminal activity by putting itself in the middle between user and terminal. Systemd Journal is used as a storage for recorded sessions.
+In this lab, you first assume the role of a third-party contractor who breaks something on your system and then the role of a system administrator who needs to find out what has happened on that system.
 
-=== cockpit-session-recording
-Our package for Cockpit uses provided APIs to access Journal and get sessions from it. It provides JavaScript based player which produces text output, but with a videoplayer-like controls.
+=== 12.1.1: Prerequisites
+* Install the required `tlog` and `cockpit-session-recording` packages
+* Configure them to record terminal activity for specific users
 
-Several packages were pre-installed for your convenience. Those are:
+The `tlog` package allows you to records terminal activity by putting itself between the user and the terminal. Systemd Journal is used as a storage for recorded sessions.
+
+The `cockpit-session-recording` package for Cockpit uses provided APIs to access the Systemd Journal and obtain sessions from it. It provides a JavaScript-based player, which produces text output, but with video player-style controls.
+
+A few packages are already installed for you:
 
 * tlog
-* cockpit
+* Cockpit
 * cockpit-session-recording
 * mc
 * nginx
 * vim
 
-== Lab 12.1 Accessing the Session Recording Lab System
-
+=== 12.1.2: Accessing the Session Recording Lab System
 All of the exercises in this lab are run on the *sessionrecording.example.com* host. You set up for user *q* to have its terminal session recorded.
 
-== Lab 12.2 Setting up recording
+== 12.2: Setting Up Recording
 
-Go to your *Lab Information* webpage from the *Lab 0 setup steps* and click on the console button for your workstation bastion host. Login as *lab-user* with *r3dh4t1!* as the password.
+. Return to your *Lab Information* web page from the *Lab 0: Setup Steps* and click *CONSOLE* for your workstation bastion host:
 +
 image:images/lab1.1-workstationconsole.png[300,300]
+
+. Log in as *lab-user* with *r3dh4t1!* as the password:
++
 image:images/lab1.1-labuserlogin.png[300,300]
 
-Open a Firefox web browser:
-
+. Open a Firefox web browser:
++
 image:images/session_recording_firefox.png[]
 
-Go to _https://sessionrecording.example.com:9090/_
-
+. Go to link:https://sessionrecording.example.com:9090/[https://sessionrecording.example.com:9090/^]:
++
 image:images/session_recording_firefox_1.png[]
 
-Login as _root_ user with *r3dh4t1!* as the password.
-
+. Log in as the *root* user with *r3dh4t1!* as the password:
++
 image:images/session_recording_cockpit_login.png[]
 
-Click on Session Recording menu item
-
+. Click the *Session Recording* menu item:
++
 image:images/session_recording_menu.png[]
 
-Then click on the button in upper righ corner with a cog icon to access the configuration.
-
+. In the upper right corner, click the cog button to access the configuration:
++
 image:images/session_recording_config.png[]
 
-Take a look on the configuration of tlog-rec-session.conf which is represented as "General Configuration" in Cockpit
-
+. Examine the configuration of `tlog-rec-session.conf`, shown in Cockpit in the *General Configuration* dialog:
++
 image:images/session_recording_tlog_conf.png[]
 
-Enable logging of user's input by clicking the corresponding checkbox:
-
+. Click *Log User's Input* to enable logging of the user's input, then click *Save*:
++
 image:images/session_recording_tlog_conf_1.png[]
 
-Then, press the "Save" button.
-
-Now you should configure users to be recorded.
-
-===== Lab 12.3 Setup recorded users using cockpit-session-recording
-
-While staying on the same page as in previous chapter do the following.
-
-Choose "*Some*" option in Scope dropdown and put "*q*" in the Users input. Then click the *Save* button.
-
+. In the SSD Configuration dialog, entering *Some* for *Scope* and *q* for *Users* to set up the *q* user to be recorded using `cockpit-session-recording`, and then click *Save*:
++
 image:images/session_recording_sssd.png[]
++
+The *q* user is set up to be recorded.
 
-Do not forget to click the *Save* button.
+== 12.3: Creating Sessions Recorded by `tlog`
 
-That is it. Now the "*q*" user will be recorded.
+In this section, you create some activity by one of the recorded users to be able to play it back in Cockpit.
 
-== Lab 12.4 Creating sessions recorded by tlog
-
-Let's create some activity by one of the recorded users. Then you will be able to play it back in Cockpit.
-
-Open the *Terminal*.
-
+. Open *Terminal*:
++
 image:images/session_recording_terminal.png[]
 
-Login using SSH to the same machine. Use *session1* as a password:
-
-    [lab-user@sessionrecording]# ssh q@sessionrecording.example.com
-
+. Use SSH to log in to the same machine, using *session1* as the password:
++
+----
+[lab-user@sessionrecording]# ssh q@sessionrecording.example.com
+----
++
 image:images/session_recording_terminal1.png[]
 
-You will see notice message in terminal right after login
-
+. Upon login, expect to see a terminal message informing the user that the session is being recorded:
++
 image:images/session_recording_notice.png[]
++
+Remember that this session is being recorded. Later, you can try to resize the session window to see if that is supported.
 
-Remember, that this session is being recorded. You could try to resize session window to see it's supported later.
-
-    [q@sessionrecording]$ mc
-
-You will see mc launched
-
+. Launch GNU Midnight Commander (`mc`):
++
+----
+[q@sessionrecording]$ mc
+----
++
+Expect `mc` to launch:
++
 image:images/session_recording_mc.png[]
 
-Try to use by navigating to various directories. Then press F10 or click on Quit button in the right bottom corner.
+. Navigate to various directories to explore them, then press *F10* or click *Quit* in the right corner.
 
-Let's imitate a real world scenario by breaking the nginx web server configuration file, so that later we will be able to investigate the problem using session recording in cockpit.
+== 12.4: Investigating Problems Using Session Recording
 
-    [q@sessionrecording]$ sudo vi /etc/nginx/nginx.conf
+In this section, you imitate a real-world scenario by breaking the `nginx` web server configuration file and then address the problem using session recording in Cockpit.
 
+. Edit the nginx configuration file:
++
+----
+[q@sessionrecording]$ sudo vi /etc/nginx/nginx.conf
+----
++
 image:images/session_recording_vi_nginx.png[]
-
++
 image:images/session_recording_nginx.png[]
 
-Let's remove *;* in the line *worker_connections 1024;* like this:
-
+. In the line `worker_connections 1024;`, remove the `;` to introduce an error:
++
 image:images/session_recording_nginx_broken.png[]
 
-Next we will restart the nginx server:
-
-    [q@sessionrecording]$ sudo systemctl restart nginx
-
-The restart will fail due to the error we created in nginx.conf file, this will be used as an example.
-You will see an error message like this:
-
+. Restart the `nginx` server:
++
+----
+[q@sessionrecording]$ sudo systemctl restart nginx
+----
++
+The restart fails due to the error you created in the `nginx.conf` file.
++
+Expect to see an error message similar to this:
++
 image:images/session_recording_nginx_error.png[]
 
-Now, it is time to login to cockpit and use cockpit-session-recording to investigate why the web server does not work.
 
-=== Lab 12.5 Using Session Player from Cockpit UI
+== 12.5: Using Session Player from Cockpit UI
 
-Go to your *Lab Information* webpage from the *Lab 0 setup steps* and click on the console button for your workstation bastion host. Login as *lab-user* with *r3dh4t1!* as the password.
+=== 12.5.1: Exploring Session Recording
+
+In this section, you log in to Cockpit and use `cockpit-session-recording` to investigate why the web server does not work.
+
+. Go to your *Lab Information* webpage from *Lab 0: Setup Steps* and click *CONSOLE* for your workstation's bastion host:
 +
 image:images/lab1.1-workstationconsole.png[300,300]
+
+. Log in as *lab-user* with *r3dh4t1!* as the password:
++
 image:images/lab1.1-labuserlogin.png[300,300]
 
-Open a Firefox web browser:
-
+. Open a Firefox web browser:
++
 image:images/session_recording_firefox.png[]
 
-Go to _https://sessionrecording.example.com:9090/_
-
+. Go to link:https://sessionrecording.example.com:9090/[https://sessionrecording.example.com:9090/^]:
++
 image:images/session_recording_firefox_1.png[]
 
-Login as *root* user with *r3dh4t1!* as the password.
-
+. Log in as *root* with *r3dh4t1!* as the password:
++
 image:images/session_recording_cockpit_login.png[]
 
-Click on the Session Recording menu item
-
+. Click the *Session Recording* menu item:
++
 image:images/session_recording_menu.png[]
 
-Your session will appear in the list of sessions. Of course data will be different. Click on it to open it:
-
+. When your session appears in the list of sessions, click it to open it:
++
 image:images/session_recording_session_list.png[]
++
+Expect your data to be different.
 
-Click on "*Play*" button to start playback of the session or just use hotkey "*p*" to achieve the same result:
-
+. Click *Play* to start the playback of the session (you can also press the hotkey *p* to achieve the same results):
++
 image:images/session_recording_play.png[]
-
-You can also navigate the session frame-by-frame using "*Skip Frame*" button or hotkey "*.*":
++
+[TIP]
+====
+You can also navigate the session frame by frame by clicking the "*Skip Frame*" button or the hotkey *.* (period):
 
 image:images/session_recording_skipframe.png[]
+====
 
-Try to play with other controls. Speed controls:
+=== 12.5.2: Using Other Session Recording Controls
 
+. Try the speed controls:
++
 image:images/session_recording_speed_control.png[]
 
-Restart playback and fast-forward to end:
-
+. Restart the playback and fast-forward to the end:
++
 image:images/session_recording_fastforward.png[]
 
-Zoom controls:
-
+. Use the zoom controls:
++
 image:images/session_recording_zoom_controls.png[]
 
-Switch between selection of text and drag'n'pan of zoomed content:
-
+. Switch between a selection of text and the drag-n-pan of zoomed content:
++
 image:images/session_recording_dragnpan.png[]
 
-Searching for appearance of a specific keyword in the session. It shows closest beginning of "frame" with match:
+=== 12.5.3: Locating the nginx Failure Cause
 
+. Enter `nginx` in the search bar to search for the first instance of the `nginx` keyword in the session:
++
 image:images/session_recording_search_button.png[]
-
-In session player the action of restarting nginx should look something like this:
-
++
+This shows the closest beginning of "frame" that matches the keyword entered.
++
+In Session Player, the action of restarting `nginx` looks similar to this:
++
 image:images/session_recording_cockpit_nginx_restart.png[]
-
-In the bottom part of the page the correlated logs are shown. You should be able to find the corresponding messages:
-
++
+Expect to find the corresponding messages at the bottom of the page:
++
 image:images/session_recording_cockpit_nginx_error.png[]
 
-Clicking on the timestamp event in the logs panel will jump to the same time in the session.
+. Click the timestamp event in the logs panel to jump to the same time in the session.
 
-You can try searching for "nginx.conf" to find time when the config was edited. The Closest time will be shown,  clicking on it will rewind the player position to that time.
-
+. Search for `nginx.conf` to find the time when the configuration file was edited, showing the nearest time:
++
 image:images/session_recording_search.png[]
 
+. Rewind the player position to that time.
+
 <<top>>
-link:README.adoc#table-of-contents[ Table of Contents ]
+
+link:README.adoc#table-of-contents[Table of Contents^]
+

--- a/2020Labs/RHELSecurity/documentation/lab1_OpenSCAP.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab1_OpenSCAP.adoc
@@ -1,275 +1,303 @@
+:toc2:
+:linkattrs:
+
 = Lab 1: OpenSCAP Basics and Command Line Scanning
 
-*Lab Length: Medium/Average (~10-20 mins)*
+.*Lab Length*
+* Medium/Average (~10-20 mins)
 
-== Goal of Lab
-The goal of this lab exercise is to introduce you to the basics of automated security and compliance scanning and remediations with OpenSCAP and Red Hat Ansible Automation.
+.*Goal*
+* Become familiar with the basics of automated security and compliance scanning and remediations with OpenSCAP and Red Hat^(R)^ Ansible^(R)^ Automation
 
-== Introduction
-Security Content Automation Protocol (SCAP) is collection of standards to enable automated vulnerability and configuration compliance.
-OpenSCAP is a family of open source SCAP tools and the SCAP Security Guide (SSG) is collection of xml-based SCAP benchmarks and content in various formats to help with compliance configuration assessment of Red Hat Enterprise Linux machines.
-Natively shipping in Red Hat Enterprise Linux, this provides practical security hardening advice and remediations for Red Hat technologies and helps with meeting security compliance requirements, making it easier to obtain security certifications and accreditations.
+== 1.1: Introduction
+Security Content Automation Protocol (SCAP) is a collection of standards to enable automated vulnerability and configuration compliance.
+OpenSCAP is a family of open source SCAP tools, and the SCAP Security Guide (SSG) is a collection of XML-based SCAP benchmarks and content in various formats to help with compliance configuration assessment of Red Hat Enterprise Linux^(R)^ (RHEL) machines.
+Natively shipping in Red Hat Enterprise Linux, OpenSCAP provides practical security hardening advice and remediations for Red Hat technologies and helps with meeting security compliance requirements, making it easier to obtain security certifications and accreditations.
 
 OpenSCAP and SSG allows you to perform both vulnerability and security compliance checks in a fully automated way.
 
-OpenSCAP is integrated in Red Hat Satellite for automated security and compliance scanning across multiple Red Hat systems at scale. OpenSCAP, Red Hat Satellite, Red Hat Ansible Automation, and Red Hat CloudForms can also all be integrated together for automated and continuous scanning and remediations for security and compliance across a hybrid environment at scale.
+OpenSCAP is integrated into Red Hat Satellite for automated security and compliance scanning across multiple Red Hat systems at scale. OpenSCAP, Red Hat Satellite, Red Hat Ansible Automation, and Red Hat CloudForms^(R)^ can also all be integrated together for automated and continuous scanning and remediations for security and compliance across a hybrid environment at scale.
 
-In this lab exercise, we will focus on single host  scanning and remediations for security vulnerabilities and compliance to security baselines using the security tools natively in Red Hat Enterprise Linux.
+In this lab, you focus on single host scanning and remediations for security vulnerabilities and compliance to security baselines using the security tools built info Red Hat Enterprise Linux.
 
-== Pre-Configured Set Up Steps (Already done for you)
-All of the steps in this pre-configured set up section have already been done for you.
-This section is for your reference only so you know what steps have already been pre-configured in this lab environment for you.
+=== 1.1.1: Setup Steps (Preconfigured)
+All of the steps in this setup section are already completed for you.
+This section is for reference only so that you know what is already configured in this lab environment.
 
-.  Red Hat Enterprise Linux 8.0 is installed on the *openscap.example.com* host. We have also pre-installed several packages on the *openscap.example.com* host.
-
-. Specifically, we pre-installed *openscap-scanner*, *scap-security-guide*, and *Ansible*. Take a look at the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, don't forget to replace the *GUID* with unique lab provided *GUID*! Note that the versions of packages installed may not be up to date. However, this will not affect this lab.
+* Red Hat Enterprise Linux 8.0 is installed on the *openscap.example.com* host.
 +
-[source, text]
-----
-[localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
-[lab-user@workstation-GUID ~]$ ssh root@openscap.example.com
- # the tool that performs the scanning
- [root@openscap]# yum install openscap-scanner
- # project that brings in security policies we will load and test agains
- [root@openscap]# yum install scap-security-guide
- # we will need this later for Ansible based remediations
- [root@openscap]# yum install ansible python-firewall
-----
-. You can verify a successful installation by running:
-+
-[source, text]
-----
- [root@openscap ~]# oscap -V
+[NOTE]
+====
+Read the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, remember to replace the *GUID* with your unique lab-provided GUID.
 
- OpenSCAP command line tool (oscap) 1.3.0
- Copyright 2009--2018 Red Hat Inc., Durham, North Carolina.
+Versions of installed packages may not be up to date, but this does not affect the lab.
+====
 
- ==== Supported specifications ====
- XCCDF Version: 1.2
- OVAL Version: 5.11.1
- CPE Version: 2.3
- CVSS Version: 2.0
- CVE Version: 2.0
- Asset Identification Version: 1.1
- Asset Reporting Format Version: 1.1
- CVRF Version: 1.1
- ...
-----
-+
-Notice that this command outputs the OpenSCAP version and versions of supported standards.
-If during your own installation it says `oscap` command not found, you need to install the OpenSCAP tooling (as detailed in  step #2 above) since this means that OpenSCAP has not been installed successfully.
-
-. Finally, SCAP Workbench has also been installed on the *openscap.example.com* server host for you.
-+
- # GUI tool for scanning and benchmark customization, a front-end for OpenSCAP
- [root@openscap ~] yum install scap-workbench
-
-== Lab 1.1 Automated Security and Compliance Scanning with OpenSCAP
-. If not already there, log in to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your unique lab provided GUID*. If needed, use the password *r3dh4t1!*
+* Additionally, *openscap-scanner*, *scap-security-guide*, and *Ansible* are installed on the *openscap.example.com* host. Take a look at the comments above each installation command for more details. If needed, the *root* password for the *openscap.example.com* host is *r3dh4t1!*. Also, don't forget to replace the *GUID* with unique lab provided *GUID*! Note that the versions of packages installed may not be up to date. However, this will not affect this lab:
 +
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+[lab-user@workstation-GUID ~]$ ssh root@openscap.example.com
+# the tool that performs the scanning
+[root@openscap]# yum install openscap-scanner
+# project that brings in security policies we will load and test agains
+[root@openscap]# yum install scap-security-guide
+# we will need this later for Ansible based remediations
+[root@openscap]# yum install ansible python-firewall
 ----
 
-. Log into the *openscap.example.com* host as *root*.
+* To verify a successful installation, run:
++
+----
+[root@openscap ~]# oscap -V
+
+OpenSCAP command line tool (oscap) 1.3.0
+Copyright 2009--2018 Red Hat Inc., Durham, North Carolina.
+
+==== Supported specifications ====
+XCCDF Version: 1.2
+OVAL Version: 5.11.1
+CPE Version: 2.3
+CVSS Version: 2.0
+CVE Version: 2.0
+Asset Identification Version: 1.1
+Asset Reporting Format Version: 1.1
+CVRF Version: 1.1
+...
+----
++
+Note that this command outputs the OpenSCAP version and versions of supported standards.
+If during your own installation a message indicates that the `oscap` command is not found, this means OpenSCAP is not successfully installed, and you must install the OpenSCAP tooling (as detailed earlier).
+
+* SCAP Workbench is also installed on the *openscap.example.com* server host for you:
++
+----
+# GUI tool for scanning and benchmark customization, a front-end for OpenSCAP
+[root@openscap ~] yum install scap-workbench
+----
+
+== 1.2: Using Automated Security and Compliance Scanning with OpenSCAP
+
+. If not already there, log in to the workstation bastion host as *lab-user* from your desktop system, replacing `GUID` with your lab-provided GUID and, if needed, using the password *r3dh4t1!*:
++
+----
+[localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
+
+. Log in to the *openscap.example.com* host as *root*:
 +
 ----
 [lab-user@workstation-GUID ~]$ ssh root@openscap.example.com
 ----
 
-. Let's take a look at the compliance content provided by `scap-security-guide`:
-+
- [root@openscap ~]# rpm -ql scap-security-guide
- ...
- /usr/share/xml/scap/ssg/content/ssg-rhel8-cpe-dictionary.xml
- /usr/share/xml/scap/ssg/content/ssg-rhel8-cpe-oval.xml
- /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
- /usr/share/xml/scap/ssg/content/ssg-rhel8-ocil.xml
- /usr/share/xml/scap/ssg/content/ssg-rhel8-oval.xml
- /usr/share/xml/scap/ssg/content/ssg-rhel8-xccdf.xml
- ...
-
-. Notice that content provided in `scap-security-guide` covers a wide range of security baselines.
-For Red Hat Enterprise Linux 8, OSPP (Protection Profile for General Purpose Operating Systems) and PCI-DSS (Payment Card Industry Data Security Standard) profiles are available.
-There are also various formats in which this is provided - human readable HTML guides, SCAP benchmarks, but also Ansible remediation playbooks.
-
-. Move to the `content` folder so we can avoid typing long paths in the subsequent exercises below:
+. Examine the compliance content provided by `scap-security-guide`:
 +
 ----
- [root@openscap ~]# cd /usr/share/xml/scap/ssg/content
+[root@openscap ~]# rpm -ql scap-security-guide
+...
+/usr/share/xml/scap/ssg/content/ssg-rhel8-cpe-dictionary.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel8-cpe-oval.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel8-ocil.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel8-oval.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel8-xccdf.xml
+...
+----
++
+Note that content provided in `scap-security-guide` covers a wide range of security baselines.
+For Red Hat Enterprise Linux 8, Protection Profile for General Purpose Operating Systems (OSPP) and  Payment Card Industry Data Security Standard (PCI-DSS) profiles are available.
+There are various formats in which this is provided--human-readable HTML guides, SCAP benchmarks, and Ansible remediation playbooks.
+
+. Move to the `content` folder so that you can avoid typing long paths in the subsequent exercises:
++
+----
+[root@openscap ~]# cd /usr/share/xml/scap/ssg/content
 ----
 
-. First, let's check which compliance profiles are available for Red Hat Enterprise Linux 8.
+. Determine which content and compliance profiles (OSPP and PCI-DSS) are available for Red Hat Enterprise Linux 8:
 +
 ----
- [root@openscap content]# oscap info ssg-rhel8-ds.xml
+[root@openscap content]# oscap info ssg-rhel8-ds.xml
 ----
-+
-. You will get list of available content and compliance profiles (OSPP - Protection Profile for General Purpose Operating Systems, and PCI-DSS) available for Red Hat Enterprise Linux 8.
 
-. Next, let's perform our first security compliance baseline scan with the OSPP profile.
-You can see in our command below that we can skip the profile ID prefix to make the command simpler.
-The real ID is *xccdf_org.ssgproject.content_profile_ospp*.
+. Perform your first security compliance baseline scan with the OSPP profile:
 +
-The scanning command has to be executed by a privileged user `root` or using `sudo`, so the scanner can access system parts that are off-limits to common users.
+The scanning command must be executed by a privileged user: `root` or using `sudo`. Therefore the scanner can access system parts that are off-limits to common users.
 The simplest scanner invocation can look like this:
 +
 ----
 oscap xccdf eval --profile ospp ./ssg-rhel8-ds.xml
 ----
 +
-However, we will also want to store the scan results, so we can process them later.
-Therefore, we have to supply additional arguments:
+You can omit the profile ID prefix to make the command simpler--the actual ID is `xccdf_org.ssgproject.content_profile_ospp`.
++
+You also want to store the scan results, so you can process them later.
+Therefore, you need to supply additional arguments.
+
+. Store the results of the scan this time:
++
+----
+[root@openscap content]# oscap xccdf eval --oval-results --profile ospp --results-arf /tmp/arf.xml --report /tmp/report.html ./ssg-rhel8-ds.xml
+----
 +
 --
-* use `--results-arf` to get machine readable results archive
-* use `--report` to get human readable report (can also be generated from ARF after the scan as you see in the next optional step)
-* use `--oval-results` for extended details of failing rules
+* `--results-arf` gets the machine-readable results archive.
+* `--report` gets a human-readable report, which can also be generated from ARF after the scan (as shown in the optional step that follows).
+* `--oval-results` provides additional details of failing rules.
 --
-+
-So now, execute:
-+
-----
- [root@openscap content]# oscap xccdf eval --oval-results --profile ospp --results-arf /tmp/arf.xml --report /tmp/report.html ./ssg-rhel8-ds.xml
-----
-+
-to run the scan, generating the HTML report as a side-effect.
 
-. (Optional) You can also generate the HTML report separately:
+. (Optional) Generate the HTML report separately:
 +
 ----
- [root@openscap content]# rm -f /tmp/report.html
- [root@openscap content]# oscap xccdf generate report /tmp/arf.xml > /tmp/report.html
+[root@openscap content]# rm -f /tmp/report.html
+[root@openscap content]# oscap xccdf generate report /tmp/arf.xml > /tmp/report.html
 ----
 
-. Now, go to your *power control and consoles* view from the *Lab Information* page where you got your assigned unique lab GUID by clicking on the link provided on the last bullet point of the Lab Information page.
+. From the *Lab Information* page where you were assigned your lab GUID, click the link provided on the bullet to go to your *power control and consoles* view:
 +
 image:images/labinfopage1.png[2000,2000]
 
-.  Click on the console button for your workstation bastion host and login as *lab-user* with *r3dh4t1!* as the password.
+. Click the console button for your workstation bastion host and log in as *lab-user* with *r3dh4t1!* as the password:
 +
 image:images/lab1.1-workstationconsole.png[300,300]
 image:images/lab1.1-labuserlogin.png[300,300]
 
-. Open the Terminal and use it to open the *report.html* (which is in the tmp directory of your openscap.example.com host) in a X forwarded web browser.
+. In an X-forwarded web browser, open Terminal and use it to open the *report.html* (which is in the `.tmp` directory of your *openscap.example.com* host):
 +
- [lab-user@workstation-GUID ~]$ ssh -X root@openscap.example.com firefox /tmp/report.html
+----
+[lab-user@workstation-GUID ~]$ ssh -X root@openscap.example.com firefox /tmp/report.html
+----
 
-. You will see the security compliance scan results for every security control in the OSPP security baseline profile in HTML format.
+. Expect to see the security compliance scan results for every security control in the OSPP security baseline profile in HTML format:
 +
 image:images/lab1.1-scapreport.png[500,500]
++
+[NOTE]
+====
+Rules can have several types of results, but the most common are *pass* and *fail*, which indicate whether a particular security control has passed or failed the scan.
+Other results you can encounter frequently are *notapplicable*, for rules that were skipped as not relevant to the scanned system, and *notchecked*, for rules without an automated check.
+====
 
-. Rules can have several types of results but the most common ones are *pass* and *fail*, which indicate whether a particular security control has passed or failed the scan.
-Other results you can frequently encounter are *notapplicable*, for rules that have been skipped as not relevant to the scanned system and *notchecked*, for rules without an automated check.
-
-. Click on any of the rule titles in the HTML report, such as the rules highlighted in red in the image below.
+. Click any of the rule titles in the HTML report, such as the rules highlighted in red in this image:
 +
 image:images/lab1.1-clickrule.png[600,600]
 
-. This will bring up a pop-up dialog that allows you to examine details of the particular OpenSCAP security rule that failed or passed.
-If the `--oval-results` option was specified on the command line when scanning, extended details are provided.
-For example, if an OpenSCAP security rule is testing file permissions on a list of files, it will specify which files failed and what are their permission bits.
-In our case, it shows which file failed regex check.
+. Wait for the dialog to appear, then examine the details of the OpenSCAP security rule that failed or passed--in this case, it shows which file failed the regex check:
 +
 image::images/lab1.1-report_pass.png[HTML report: A rule that is passing]
 +
-
 image::images/lab1.1-report_fail.png[HTML report: A rule that is failing]
++
+If the `--oval-results` option is specified on the command line when scanning, extended details are provided.
+For example, if an OpenSCAP security rule is testing file permissions on a list of files, it specifies which files failed and their permission bits.
 
-. Feel free to browse through the report to see all the different checks that were performed.
-Machine is in state equivalent to default installation.
-When you are done, you can close Firefox window.
+. Browse through the report to see all of the different checks performed.
++
+The machine is in a state equivalent to a default installation.
 
-== Lab 1.2 Customizing Existing SCAP Security Profiles using SCAP Workbench
-. Now, let's go back to the workstation console page. Click on the console button for your workstation bastion host and login as lab-user with r3dh4t1! as the password.
+. When you are finished, close the Firefox window.
+
+== 1.3: Customizing SCAP Security Profiles Using SCAP Workbench
+
+=== 1.3.1: Using SCAP Workbench
+
+. Return to the workstation console page, click the console button for your workstation bastion host, and log in as *lab-user* with *r3dh4t1!* as the password:
 +
 image:images/lab1.1-workstationconsole.png[300,300]
 image:images/lab1.1-labuserlogin.png[300,300]
 
-. Once you log in, open the Terminal and use it to open SCAP Workbench that's installed on the openscap.example.com system using SSH with X forwarding.
-+
- [lab-user@workstation-GUID ~]$ ssh -X root@openscap.example.com scap-workbench
+. After you log in, open Terminal.
 
-. After Workbench starts, select *RHEL8* and click on *Load Content* to open the compliance content for Red Hat Enterprise Linux 8.
+. Use SSH with X forwarding to run SCAP Workbench, which is installed on the *openscap.example.com* host:
++
+----
+[lab-user@workstation-GUID ~]$ ssh -X root@openscap.example.com scap-workbench
+----
+
+. After SCAP Workbench starts, select *RHEL8* and click *Load Content* to open the compliance content for Red Hat Enterprise Linux 8:
 +
 image:images/lab1.2-scapsecurityguide.png[600,600]
 +
 image::images/lab1.2-workbench_opened.png[SCAP Workbench opened, profile selected]
 
-. Let's customize the PCI-DSS Control baseline.
-Select this profile from the *Profile* drop-down list.
-Click *Customize*.
+=== 1.3.2: Customizing PCI-DSS Control Baseline and Tests 
+
+. For *Profile*, select *PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 8 (18)*, then click *Customize*:
 +
 image:images/lab1.2-selectcustomize.png[700,700]
 
-. In the *Customize Profile* pop-up window, leave the default New Profile ID name and click *OK*.
+. In the *Customize Profile* window, leave the default *New Profile ID* name and click *OK*:
 +
 image:images/lab1.2-newprofileID.png[500,500]
++
+Now you can select and unselect rules according to your organization's needs and change values such as minimum password length to tailor the compliance profile.
++
+The toolbar at the top of the window provides options to help you create and customize the profile. Notice the *Deselect All* and *Search* buttons, which can be very useful when creating a new profile from scratch. 
 
-. Now you can select and unselect rules according to your organization's needs and change values such as minimum password length to tailor the compliance profile.
-Notice the toolbar at the top of the window with options that can help you with the profile composition - especially the `Deselect All` and `Search` functionality buttons are likely to be very useful when composing a new profile from scratch.
-Feel free to customize this profile however you would like. After you are done customizing this profile, click *OK* to save the profile.
-You have now created a new custom profile.
+. Customize the profile as you like, then click *OK* to save it:
 +
 image::images/lab1.2-workbench_tailoring.png[SCAP Workbench content customization]
 
-. Now let's run a test scan with the new custom profile we just created.
-Click *Scan* and inspect the results.
-When prompted for the password for *lab-user*, type *r3dh4t1!*.
-This will take a few minutes so feel free to move on with the rest of this lab exercise and not wait until the scan is completed. You can ignore and close the diagnostics window that will pop up at the end of the scan.
+. Click *Scan* to run a test scan with the new custom profile you just created, typing *r3dh4t1!* when prompted for the *lab-user* password, then inspect the results:
 +
 image:images/lab1.2-scapworkbenchscan.png[500,500]
++
+This take a few minutes to complete.
++
+[NOTE]
+You may proceed with the remainder of this lab before the scan completes. You can ignore and close the diagnostics window that appears at the end of the scan.
 
-. (Optional) You can save it to a tailoring file by selecting *File->Save Customization Only*.
+. (Optional) Select *File->Save Customization Only* to save the customization to a tailoring file:
 +
 image:images/lab1.2-savecustomization.png[300,300]
 
+== 1.4: Automated Security Remediations with OpenSCAP and Ansible
+Putting the machine into compliance--for example, by changing its configuration--is called *remediation* in SCAP terminology.
+Because remediation changes the configuration of the machine to restrict its capabilities, it is possible for you to lock yourself out or disable workloads important to you.
+As a result, it is a best practice to test the remediation and its effects before deploying.
 
-== Lab 1.3 Automated Security Remediations with OpenSCAP and Ansible
-Putting the machine into compliance (for example by changing its configuration) is called *remediation* in the SCAP terminology.
-As remediation changes the configuration of the machine to restrict its capabilities, it is possible that you will lock yourself out or disable workloads important to you.
-As a result, it is best practice to test the remediation and its effects before deploying.
-
-. If not already there, open the Terminal and log into the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+=== 1.4.1: Testing Remediation
+. If not already there, open Terminal and log in to the workstation bastion host as *lab-user* from your desktop system, replacing `GUID` with your lab-provided GUID and using the password *r3dh4t1!*:
 +
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
-. Log into the *openscap.example.com* host as *root*.
+
+. Log in to the *openscap.example.com* host as *root*:
 +
 ----
 [lab-user@workstation-GUID ~]$ ssh root@openscap.example.com
 ----
-
-. All remediations will be executed on the *openscap.example.com* host.
-You will not make modifications to any other hosts, including the *workstation.example.com* bastion host.
-
-. Let's automatically generate an Ansible playbook that will put the *openscap.example.com* machine into compliance based on a given security compliance profile. In this step, let's go ahead and generate a playbook from the previous scan results of the OSPP security baseline profile:
 +
-Use the `--fix-type ansible` option to request an ansible playbook with the scan result fixes:
-+
-----
- [root@openscap]# oscap xccdf generate fix --fix-type ansible --result-id "" /tmp/arf.xml > playbook.yml
-----
+All remediations are executed on the *openscap.example.com* host.
+You do not make modifications to any other hosts, including the *workstation.example.com* bastion host.
 
-. (Optional) Generate the bash remediation script.
-This can be accomplished by running:
-* use `--fix-type bash` to request a bash script with the fixes
+. Automatically generate an Ansible Playbook
+using the `--fix-type ansible` option to request a playbook with the scan result fixes:
 +
 ----
- [root@openscap]# oscap xccdf generate fix --fix-type bash --result-id "" /tmp/arf.xml > bash-fix.sh
+[root@openscap]# oscap xccdf generate fix --fix-type ansible --result-id "" /tmp/arf.xml > playbook.yml
 ----
-. By running either this automatically generated Ansible remediation playbook or bash remediation script, the *openscap.example.com* machine will be put into compliance to the OSPP security baseline profile.
-
-. Notice that in both cases we are using empty `--result-id`.
-This is a trick to avoid specifying the full result ID.
-
-. We will focus on the Ansible remediation options in this next part of the lab exercise.
-
-. Let's open the generated playbook using a text editor.
-In this example, we will use nano as our text editor (but feel free to use vi as well).
 +
-....
+This puts the *openscap.example.com* machine into compliance based on a given security compliance profile from the previous scan results of the OSPP security baseline profile.
+
+. (Optional) Generate the bash remediation script using `--fix-type bash` to request a bash script with the fixes:
++
+----
+[root@openscap]# oscap xccdf generate fix --fix-type bash --result-id "" /tmp/arf.xml > bash-fix.sh
+----
++
+By running either the automatically generated Ansible remediation playbook or the bash remediation script, the *openscap.example.com* machine is put into compliance to the OSPP security baseline profile.
++
+TIP: Note that in both cases you use an empty `--result-id`. This is a trick to avoid specifying the full result ID.
+
+=== 1.4.2: Setting Ansible Remediation Options
+
+In this section, you focus on the Ansible remediation options.
+
+. Open the generated playbook using a text editor (nano is used here, but vi can also be used):
++
+----
 [root@openscap]# nano playbook.yml
 ---
 ###############################################################################
@@ -285,11 +313,11 @@ In this example, we will use nano as our text editor (but feel free to use vi as
 # $ ansible-playbook -i inventory.ini playbook.yml
 #
 ###############################################################################
-....
+----
 
-. When you look at the generated playbook in more detail, you will notice the various Ansible tasks for configuring this machine to make it compliant to the OSPP security baseline profile:
+. Examine the generated playbook in detail and note the various Ansible tasks for configuring this machine to make it compliant with the OSPP security baseline profile:
 +
-....
+----
    - name: Ensure gpgcheck Enabled For All Yum Package Repositories
       with_items: "{{ yum_find.files }}"
       lineinfile:
@@ -310,13 +338,11 @@ In this example, we will use nano as our text editor (but feel free to use vi as
         - NIST-800-171-3.4.8
         - PCI-DSS-Req-6.2
         - CJIS-5.10.4.1
-....
+----
 
-. You can customize the playbook by changing the variables listed at the top of the generated file.
-Let's change the password minimum length by setting the `var_password_pam_minlen` to `!!str 18`.
-After making this change, press *control + x* , then type *y* and press *enter* in your nano text editor to save your changes.
+. Customize the playbook by changing the variables listed at the top of the generated file--in this case, change the password minimum length by setting the `var_password_pam_minlen` to `!!str 18`:
 +
-....
+----
    vars:
       var_accounts_password_minlen_login_defs: !!str 15
       var_accounts_passwords_pam_faillock_deny: !!str 3
@@ -334,17 +360,25 @@ After making this change, press *control + x* , then type *y* and press *enter* 
       var_system_crypto_policy: !!str FIPS
       rsyslog_remote_loghost_address: !!str logcollector
 ...
-....
+----
++
+[TIP]
+====
+After making this change, press *Ctrl+X*, then type *y* and press *Enter* in your nano text editor to save your changes.
+====
 
-. Let's run the playbook locally in check mode to see how it would change the machine to put it into compliance to the OSPP security baseline profile.
+. Run the playbook locally on the *openscap.example.com* host in check mode to see how it would change the machine to put it into compliance with the OSPP security baseline profile:
++
+----
+[root@openscap]# ansible-playbook -i "localhost," -c local --check playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+----
++
+[IMPORTANT]
+====
 Setting `ansible_python_interpreter` is a workaround for a known issue in the Ansible 2.7 binary installed on the lab machines.
-Make sure you run this on the *openscap.example.com* host:
+====
 +
 ----
- [root@openscap]# ansible-playbook -i "localhost," -c local --check playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3'
-----
-+
-....
 [WARNING]: While constructing a mapping from /root/playbook.yml, line 26, column 7, found a duplicate dict key (var_accounts_passwords_pam_faillock_deny). Using last defined value only.
 
 [WARNING]: While constructing a mapping from /root/playbook.yml, line 26, column 7, found a duplicate dict key (var_accounts_passwords_pam_faillock_unlock_time). Using last defined value only.
@@ -370,11 +404,13 @@ changed: [localhost]
 
 PLAY RECAP *********************************************************************
 localhost                  : ok=458  changed=260  unreachable=0    failed=0
-....
-
-. This command will take a while to finish.
-If you omit the `--check` parameter from the previous command, you will get a machine compliant with the provided rules in the OSPP security baseline profile . Please note that you won't be able to log in again into the *openscap.example.com* machine after running the previous Ansible remediation command. This is because the machine is hardened with the Ansible remediation playbook for the OSPP security baseline profile and one of the requirements of the OSPP security baseline profile prohibits login as root.
+----
++
+This command takes a while to finish.
++
+IMPORTANT: If you omit the `--check` parameter from the previous command, the resulting machine is compliant with the provided rules in the OSPP security baseline profile. Note that you are able to log in again to the *openscap.example.com* machine after running the previous Ansible remediation command. This is because the machine is hardened with the Ansible remediation playbook for the OSPP security baseline profile and one of the requirements of the OSPP security baseline profile prohibits login as *root*.
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab2_SELinux.adoc[Lab 2: SELinux]
+link:README.adoc#table-of-contents[ Table of Contents^ ] | link:lab2_SELinux.adoc[Lab 2: SELinux^]
+

--- a/2020Labs/RHELSecurity/documentation/lab2_SELinux.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab2_SELinux.adoc
@@ -1,218 +1,236 @@
+:toc2:
+:linkattrs:
 
-= Lab 2: Security Enhanced Linux (SELinux)
+== Lab 2: Security Enhanced Linux (SELinux)
 
-*Lab Length: Long (~30 mins)*
+.*Lab Length*
+* Long (~30 mins)
 
-== Goal of Lab
-The goal of this lab is to use Security Enhanced Linux (SELinux) to help mitigate attacks due to privilege escalation vulnerabilities in a three part exercise.
+.*Goal*
+Use Security Enhanced Linux^(R)^ (SELinux) to mitigate attacks that exploit privilege escalation vulnerabilities
 
-* In the first part of this lab exercise, you will become a hacker and try to execute vulnerabilities on given Red Hat Enterprise Linux 7 and Fedora systems and explore how SELinux can help to protect these systems.
-* In the second part of this lab exercise, you will turn SELinux on for an environment of web servers in an automated fashion using Ansible.
-* In the last part of this lab exercise, you will configure SELinux according to a U.S. Department of Defense STIG security control policy rule.
+== 2.1: Introduction
+Security Enhanced Linux (SELinux) can help proactively mitigate systems from the consequences of exploits during the window of vulnerability--that period of time after an exploit is discovered and before a security fix is released. This protection is provided by defining SELinux policies on your systems.
 
-== Introduction
-Security Enhanced Linux (SELinux) can help to proactively mitigate systems from the consequences of exploits during the window of vulnerability. Specifically, this is the time window before a security fix is released. This protection is done by defining SELinux policies on your systems.
+* In the first and second sections of the lab, you assume the role of a hacker and exploit vulnerabilities on given Red Hat^(R)^ Enterprise Linux^(R)^ 7 and Fedora systems, and then you explore how SELinux can help to protect these systems.
+* In the third section, you use Ansible^(R)^ to turn SELinux on for an environment of web servers in an automated fashion.
+* In the last section, you configure SELinux according to a U.S. Department of Defense STIG security control policy rule.
 
-=== SELinux policy
-SELinux *isolates* all processes running on the system to *mitigate* attacks which take advantage of privilege escalation vulnerabilities. A privilege escalation vulnerability means that a process gains more access rights than it should have. To prevent this, SELinux enforces Mandatory Access Control (MAC) mechanism over all processes. It labels every process, file, or directory according to rules specified in a security policy known as the SELinux policy. The SELinux policy also specifies how processes interact with each other and how they can access files and directories. SELinux denies every action that it is not explicitly allowed by the SELinux policy.
+=== 2.1.1: SELinux Policy
+SELinux *isolates* all of the processes running on the system to *mitigate* attacks that take advantage of privilege escalation vulnerabilities. A privilege escalation vulnerability exists whenever a process gains more access rights than it is allowed to have. To prevent this, SELinux enforces a Mandatory Access Control (MAC) policy over processes running on the system. It labels every process, file, or directory according to rules specified in a security policy known as the SELinux policy. The policy also specifies how processes interact with each other and how they can access files and directories. SELinux denies every action that it is not explicitly allowed by the policy.
 
-In one of the below exercises, we'll see an example where using this process isolation can help protect us from a privilege escalation vulnerability of an exploit.
+In the following sections, you see examples where using this process isolation can help protect you from an exploit of a privilege escalation vulnerability.
 
-=== Introduction to the Shellshock vulnerability and SELinux
-
-The Shellshock vulnerability is a bash exploit and the root issue is that you could put any command after the _env_ variable in a command , which allows an attacker to execute any arbitrary code. The following pictures shows an example of the bash exploit on an apache server.
+=== 2.1.2: Shellshock Vulnerability and SELinux
+The Shellshock vulnerability is a `bash` exploit that adds a command after the `env` variable in a command, which allows an attacker to execute arbitrary code. The following image shows an example of the `bash` exploit on an Apache server:
 
 image:images/lab2-shellshock-1.png[]
 
-If you had a _cgi_ script accessing user data or the internal network, then this script could compromise either the internal network or user data on your system.
+If you have a CGI script accessing user data or the internal network, this script can compromise both the internal network and user data on your system.
 
-_So what can SELinux do to mitigate the Shellshock bash exploit?_
+So what can SELinux do to mitigate the Shellshock `bash` exploit?
 
-The important fact to understand is that *SELinux does not block the exploit* but it will *prevent escalation of confined domains*. These confined domains are defined by the SELinux policy installed on a system. Because *SELinux controls on their types (SELinux labels)*, the process is doing what it was designed to do and can not access what is not allowed in the SELinux policy.
+It is important to understand that SELinux does not _block_ the exploit, but rather _prevents escalation_ from confined domains. These confined domains are defined by the SELinux policy installed on a system. Because SELinux places _controls_ on its types (SELinux labels), the process is limited to doing what it was designed to do and cannot access what is not allowed by the SELinux policy.
 
-The picture below shows the situation described above with SELinux enabled and in enforcing mode.
+This image shows the situation as described with SELinux enabled and in enforcing mode:
 
 image:images/lab2-shellshock-2.png[]
 
-If an attacker executed the potential _cgi_ script mentioned earlier, the attacker would not be able to access either user data or certain parts of the internal network as it is defined in the SELinux policy.
+While the attacker can execute the CGI script, the attacker is not able to access either user data or certain parts of the internal network as defined in the SELinux policy.
 
-How is this done in reality? How do types, which ensure described process separation, look in reality? The below exercises will help answer these questions.
+The following sections describe how types provide process separation and how SELinux is able to mitigate the exploit's effects.
 
-== Lab 2.1 Exploiting Red Hat Enterprise Linux 7 with the Shellshock vulnerability
+== 2.2: Exploiting Red Hat Enterprise Linux 7 with Shellshock Vulnerability
 
-=== Goal of Lab 2.1
-In this first exercise, let's become a hacker and try to exploit Red Hat Enterprise Linux 7 with the Shellshock vulnerability.
+In this part of the lab, you assume the role of a hacker and exploit Red Hat Enterprise Linux 7 (RHEL 7) using the Shellshock vulnerability.
 
-As an administrator of Red Hat Enterprise Linux servers, I want to enable SELinux for the web servers in my environment to mitigate damages caused by zero day vulnerabilities.
+As an administrator of Red Hat Enterprise Linux servers, you want to enable SELinux for the web servers in your environment to mitigate damages caused by zero-day vulnerabilities.
 
-This lab exercise is split into three steps:
+In this section, you exploit a RHEL system first with SELinux in permissive mode and again with SELinux in enforcing mode. You then analyze the SELinux denials.
 
-. Exploiting a RHEL system with SELinux in Permissive mode
-. Exploiting a RHEL system with SELinux in Enforcing mode
-. Analyzing SELinux denials
+=== 2.2.1: Logging in to the System and Navigating to the SELinux Scripts Directory
 
-=== Lab 2.1.1 Logging into the *selinux1.example.com* system and navigating to the selinux scripts directory
+In this section, you log in to the *selinux1.example.com* system and navigate to the SELinux scripts directory.
 
-The exploit will be executed from the _selinux1.example.com_ system.
+The exploit is executed from the *selinux1.example.com* system.
 
-. If not already there, log into to the bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. If you are not already there, log in to the bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
+----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
 
-. If not already root, become *root* and then log into the _selinux1.example.com_ system.
+. If you are not already *root*, become *root* and then log in to the *selinux1.example.com* system:
 +
-[source]
+----
 [lab-user@workstation-GUID ~]# ssh root@selinux1.example.com
+----
 
-. Move to directory /root/selinux_scripts/ where are all the scripts needed to perform the attack.
-
-    [root@selinux1 ~]# cd /root/selinux_scripts
+. Change to the `/root/selinux_scripts/` directory that has the scripts needed to perform the attack:
 +
-NOTE: If you'd like copies of these selinux_scripts, they can also be found in this github link https://github.com/RedHatDemos/SecurityDemos/tree/master/2019Labs/RHELSecurityLab/scripts/selinux_scripts[here^].
+----
+[root@selinux1 ~]# cd /root/selinux_scripts
+----
++
+NOTE: You can find copies of these `selinux_scripts` at this link:https://github.com/RedHatDemos/SecurityDemos/tree/master/2019Labs/RHELSecurityLab/scripts/selinux_scripts[Red Hat GitHub security demos link^].
 
-. Repeat steps #1-3 above on a second terminal (this terminal window will also be connected to *selinux1.example.com*)
+. Repeat the previous steps in this section on a second terminal that is also connected to *selinux1.example.com*.
 
-=== Lab 2.1.2 Exploiting the system with SELinux in Permissive mode
+=== 2.2.2: Exploiting the System with SELinux in Permissive Mode
 
-==== Goal of Lab 2.1.2
-In this part of the lab exercise, we are going to utilize the two open terminals from the previous exercise.
-(both selinux1.example.com). The first terminal window will be for listening on 9999 tcp port and the second terminal window will be for executing the exploit script.
+In this section, using the two terminal shells that you opened on *selinux1.example.com*, you listen on TCP port 9999 (in the first shell) and execute the exploit script (in the second).
 
-==== Introduction
-Let's see this visually. Take a look at the image below. This image describes the flow of how the exploit that will be executed. On the left side is the victim server (selinux4 system). From the attacker machine (which is the selinux1 system), a http request will be sent and part of this http request will be to open the shell to the attacker machine listening on tcp port 9999.
+This image depicts how the exploit is executed:
 
 image:images/lab2-shellshock-flow.png[]
 
+On the left, you see the victim server, the *selinux4* system. An HTTP request is sent to this server from the attacker machine *selinux1* on the right.
+The HTTP request opens a shell to the attacker machine, which is listening on port 9999.
 
-==== Lab 2.1.2 exercise steps
-Now let's go through the steps we just described above.
+The victim server, *selinux4*, has SELinux set up in permissive mode by default. It is running the Apache web server and an older version of bash.
 
-. Go to your two opened terminals that are connected to the *selinux1.example.com* systems and pointed to the /root/selinux_scripts directory.
+. In the first terminal shell that you opened earlier on *selinux1.example.com* and whose working directory is `/root/selinux_scripts`, start Ncat listening on TCP port 9999:
++
+----
+[root@selinux1 selinux_scripts]# nc -lvp 9999
+Ncat: Version 7.50 ( https://nmap.org/ncat )
+Ncat: Listening on :::9999
+Ncat: Listening on 0.0.0.0:9999
+----
++
+Ncat is a feature-packed networking utility that reads and writes data across networks.
 
-. Note that the victim server, _selinux4_, has SELinux in permissive mode by default. It is running the Apache service running with an older version of bash. Everything is ready to run the exploit.
+. From the second *selinux1* terminal, run the exploit:
++
+----
+[root@selinux1 selinux_scripts]# ./shellshock_exploit.sh
+----
 
-. Based on flow of the ShellShock attack we learned about earlier, it's necessary to start listening on tcp port 9999 on one of the selinux1 terminals you have opened. We'll be using Ncat, which is a feature-packed networking utility which reads and writes data across networks from the command line.
+. Back on the first *selinux1* terminal (where you executed `nc`), look for a `bash` prompt to appear:
++
+----
+[root@selinux1 selinux_scripts]# nc -lvp 9999
+Ncat: Version 7.50 ( https://nmap.org/ncat )
+Ncat: Listening on :::9999
+Ncat: Listening on 0.0.0.0:9999
+Ncat: Connection from 192.168.0.24.
+Ncat: Connection from 192.168.0.24:38668.
+bash: no job control in this shell
+bash-4.2$
+----
 
-    [root@selinux1 selinux_scripts]# nc -lvp 9999
-    Ncat: Version 7.50 ( https://nmap.org/ncat )
-    Ncat: Listening on :::9999
-    Ncat: Listening on 0.0.0.0:9999
+. At the bash prompt that appeared in the *selinux1* shell, type *id*, then *uname -a*, followed by *exit* to see the results of the exploit:
++
+----
+bash-4.2$ id
+id
+uid=48(apache) gid=48(apache) groups=48(apache) context=system_u:system_r:httpd_sys_script_t:s0
+bash-4.2$ uname -a
+uname -a
+Linux selinux4.example.com 3.10.0-418.el7.x86_64 #1 SMP Thu May 26 20:35:02 EDT 2016 x86_64 x86_64 x86_64 GNU/Linux
+bash-4.2$ exit
+----
++
+As you can see from the resulting output, these commands were executed on *selinux4*, the victim server (*selinux4*), despite the fact that the session was started on the attacker machine (*selinux1*).
++
+The `id` command prints real and effective user and group IDs, where the user and group are `apache`, demonstrating that the CGI script was started as the Apache user.
++
+The `uname` command prints system information. You can see the *selinux4.example.com* host name being printed, which indicates that this is the victim system.
++
+These commands indicate that the attack succeeded.
 
-. Now, from the other *selinux1* terminal, let's run the exploit:
+=== 2.2.4: Exploiting the System with SELinux in Enforcing Mode
 
-    [root@selinux1 selinux_scripts]# ./shellshock_exploit.sh
+The victim server (*selinux4*) has been running SELinux in permissive mode. In this section, you switch SELinux to enforcing mode and then repeat the attack.
 
-. Now, on the terminal where nc command was executed, a bash prompt should now appear.
+. Connect to *selinux4* and switch to enforcing mode:
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux4 setenforce 1
+----
 
-    [root@selinux1 selinux_scripts]# nc -lvp 9999
-    Ncat: Version 7.50 ( https://nmap.org/ncat )
-    Ncat: Listening on :::9999
-    Ncat: Listening on 0.0.0.0:9999
-    Ncat: Connection from 192.168.0.24.
-    Ncat: Connection from 192.168.0.24:38668.
-    bash: no job control in this shell
-    bash-4.2$
+. Begin the Shellshock attack again by listening on TCP port 9999 in one of the terminal shells for the *selinux1* system:
++
+----
+[root@selinux1 selinux_scripts]# nc -lvp 9999
+Ncat: Version 7.50 ( https://nmap.org/ncat )
+Ncat: Listening on :::9999
+Ncat: Listening on 0.0.0.0:9999
+----
 
-. For testing purpose, few commands could be executed on the victim system (_selinux4_). Type *id* and then type *uname -a*. Then type *exit*.
+. From the other terminal shell on the *selinux1* system, run the exploit again:
++
+----
+[root@selinux1 selinux_scripts]# ./shellshock_exploit.sh
+----
++
+This time there is no `bash` prompt on the terminal where you executed the `nc` command. This is because SELinux blocked this access.
 
-    bash-4.2$ id
-    id
-    uid=48(apache) gid=48(apache) groups=48(apache) context=system_u:system_r:httpd_sys_script_t:s0
-    bash-4.2$ uname -a
-    uname -a
-    Linux selinux4.example.com 3.10.0-418.el7.x86_64 #1 SMP Thu May 26 20:35:02 EDT 2016 x86_64 x86_64 x86_64 GNU/Linux
-    bash-4.2$ exit
+=== 2.2.5: Analyzing the SELinux Denial
 
-* The _id_ command prints real and effective user and group IDs, where we could see that user and group is apache. This is because cgi scripts are started as the apache owner.
-* The _uname_ command prints system information. You can see the hostname *selinux4.example.com* being printed, which indicates that this is the victim system. These commands prove that the attack was successful.
+In this section, you analyze what happened and why SELinux blocked the Shellshock exploit.
 
-=== Lab 2.1.3 Set SELinux to enforcing mode
+. Connect to the *selinux4* system from the *selinux1* machine:
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux4
+[root@selinux4 ~]# ausearch -m AVC -ts today | grep name_connect
+type=AVC msg=audit(1524909646.681:86): avc:  denied  { name_connect } for  pid=2091 comm="bashbug.sh" dest=9999 scontext=system_u:system_r:httpd_sys_script_t:s0 tcontext=system_u:object_r:jboss_management_port_t:s0 tclass=tcp_socket
+----
++
+This is the AVC record from the *audit* daemon. It says that the CGI script, called `bashbug.sh` (labeled as `httpd_sys_script_t`) tried to connect to TCP port 9999 (labeled as `jboss_management_port_t`). There is no `allow` rule for this access, so the kernel denied access. This demonstrates that SELinux mitigated this attack.
 
-The victim server (_selinux4_ system) has SELinux in permissive mode. Now, let's switch SELinux to enforcing and repeat the attack.
+== 2.3: Exploiting Fedora 27 with a Runcescape Vulnerability
 
-Connect to _selinux4_ and switch to Enforcing mode
+The CVE-2019-5736 `runc` escape is the latest vulnerability in the area of containers. It is a privilege escalation vulnerability that allows arbitrary code execution as *root* when a malicious process inside a container escapes from the container namespace and executes on the host system. Because any container can contain a malicious process, a container can gain root access to the entire system when a system administrator starts that container.
 
-    [root@selinux1 selinux_scripts]# ssh root@selinux4 setenforce 1
+Fortunately, SELinux technology, which separates containers from each other and from the host system, blocks this exploit.
 
-=== Lab 2.1.4 Exploiting system with SELinux in Enforcing mode
+NOTE: For more information about this exploit, see link:https://access.redhat.com/security/vulnerabilities/runcescape[Runcescape Security Vulnerability^].
 
-Now, let's repeat the attack but this time with SELinux in Enforcing mode on the victim server (_selinux4_ ).
+In this section, you assume the role of a hacker and try to exploit Fedora 27 using the Runcescape vulnerability. As mentioned, this vulnerability in `runc` allows breaking out from a container to gain root-level access on the host machine.
 
-Based on flow of the _ShellShock_ attack, let's again start listening on tcp port 9999 on one of the terminals for the _selinux1_ system.
+An earlier release of Fedora 27 is used for the purpose, because the Docker vulnerability is fixed in Red Hat Enterprise Linux 7. Fedora 27 is in its end-of-life state, which means no updates are provided and its Docker daemon is still vulnerable.
 
-    [root@selinux1 selinux_scripts]# nc -lvp 9999
-    Ncat: Version 7.50 ( https://nmap.org/ncat )
-    Ncat: Listening on :::9999
-    Ncat: Listening on 0.0.0.0:9999
+As an administrator of Red Hat Enterprise Linux servers, you want to enable SELinux for containers in your environment to mitigate damages caused by zero-day vulnerabilities.
 
-_Ncat_ is a feature-packed networking utility which reads and writes data across networks from the command line.
+This lab exercise consists of three key parts:
 
-Now, from another terminal for the selinux1 system, let's run the exploit again.
+* Exploiting a Fedora system with SELinux in _enforcing_ mode
+* Exploiting a Fedora system with SELinux in _permissive_ mode
+* Analyzing SELinux denials
 
-    [root@selinux1 selinux_scripts]# ./shellshock_exploit.sh
+=== 2.3.1: Logging in to the *selinux6.example.com* System and Navigating to the `selinux` Directory
 
-As you can see, this time around, there is no bash prompt on the terminal where you executed the _nc_ command. This is because SELinux blocked this access. SELinux did its job!
+The exploit is executed from the *selinux6.example.com* system.
 
-=== Lab 2.1.5 Analyzing the SELinux denial
-
-Let's analyze what happened and why SELinux blocked the ShellShock exploit.
-
-Connect to the selinux4 system from the selinux1 machine
-
-    [root@selinux1 selinux_scripts]# ssh root@selinux4
-    [root@selinux4 ~]# ausearch -m AVC -ts today | grep name_connect
-    type=AVC msg=audit(1524909646.681:86): avc:  denied  { name_connect } for  pid=2091 comm="bashbug.sh" dest=9999 scontext=system_u:system_r:httpd_sys_script_t:s0 tcontext=system_u:object_r:jboss_management_port_t:s0 tclass=tcp_socket
-
-This is the avc record from the Audit daemon. This output is saying that the cgi script, called bashbug.sh , labeled as httpd_sys_script_t tried to connect to tcp port 9999 labeled as jboss_management_port_t. Fortunately, there is no allow rules for this access. As a result, the access was denied by the kernel and SELinux mitigated this attack.
-
-== Lab 2.2 Exploiting Fedora 27 with the Runcescape vulnerability
-
-==== Introduction
-CVE-2019-5736 runc escape is the latest vulnerability in containers world. It's privilege escalation vulnerability with arbitrary code execution as root, when malicious process inside container will escape from container namespace and will execute arbitary code on host system. This is really dangerous because in any container could be malicious process and when system administrator will start the container, they will add root access to the whole system.
-Fortunately, SELinux technology, which separates containers between each other and also separates containers from the host system, blocks this exploit.
-
-NOTE: If you'd like to read more about this exploit, information can be found in this link https://access.redhat.com/security/vulnerabilities/runcescape[here^].
-
-=== Goal of Lab 2.2
-
-In this second exercise, let's become a hacker and try to exploit Fedora 27 with the Runcescape vulnerability. A vulnerability discovered in runc allows for a break out from the container to gain root-level access on the host machine.
-
-
-Old release of Fedora27 was used for the purpose, because docker is fixed in Red Hat Enterprise Linux 7. Fedora27 is in end of life state, which means no updates are provided, so docker there is still vulnerable.
-
-As an administrator of Red Hat Enterprise Linux servers, I want to enable SELinux for the containers in my environment to mitigate damages caused by zero day vulnerabilities.
-
-This lab exercise is split into three steps:
-
-. Exploiting a Fedora system with SELinux in Enforcing mode
-. Exploiting a Fedora system with SELinux in Permissive mode
-. Analyzing SELinux denials
-
-=== Lab 2.2.1 Logging into the *selinux6.example.com* system and navigating to the selinux directory
-
-The exploit will be executed from the _selinux6.example.com_ system.
-
-. If not already there, log into to the bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
-[source]
+. If not already there, log in to the bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
++
+----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
 
-. If not already root, become *root* and then log into the _selinux6.example.com_ system.
-[source]
+. If you are not already *root*, become *root* and then log in to the *selinux6.example.com* system:
++
+----
 [lab-user@workstation-GUID ~]# ssh root@selinux6.example.com
+----
 
-. Move to directory /root/selinux_scripts/ where are all the scripts needed to perform the attack.
-[source]
+. Change to the `/root/selinux_scripts/` directory that has the scripts needed to perform the attack:
++
+----
 [root@selinux6 ~]# cd /root/selinux_scripts
+----
++
+NOTE: You can find copies of these `selinux_scripts` at this  link:https://github.com/RedHatDemos/SecurityDemos/tree/master/2019Labs/RHELSecurityLab/scripts/selinux_scripts[Red Hat GitHub security demos link^].
 
+=== 2.3.2: Reproducing the Attack
 
-NOTE: If you'd like copies of these selinux_scripts, they can also be found in this github link https://github.com/RedHatDemos/SecurityDemos/tree/master/2019Labs/RHELSecurityLab/scripts/selinux_scripts[here^].
+In this section, you reproduce the attack. First, you verify the state of the host system, then you prepare the environment, and finally you execute the program within the container.
 
-==== Lab 2.2.2 exercise steps
-Now, let's follow these steps to reproduce the attack.
-
-. First step is to check if the host system is running SELinux in *enforcing* state.
-[source]
+. Verify that the host system is running SELinux in _enforcing_ mode:
++
+----
 [root@selinux6 selinux_scripts]# sestatus
 SELinux status:                 enabled
 SELinuxfs mount:                /sys/fs/selinux
@@ -224,191 +242,238 @@ Policy MLS status:              enabled
 Policy deny_unknown status:     allowed
 Memory protection checking:     actual (secure)
 Max kernel policy version:      31
+----
++
+Now you prepare the environment for the attack. A `runcescape.sh` shell script is already prepared for you. The script installs and starts a Docker container engine that has the vulnerable `runc` bundled inside. Then a standard container with the latest Ubuntu distribution is downloaded. Finally, the script uploads a malicious program to the container and prepares the exploit.
 
-. Second step is to prepare the environment, for this purpose there is *runcescape.sh* shell script prepared for you. The script will install and start docker container engine. This engine also uses a vulnerable runc bundled inside. Then regular container with the latest ubuntu distribution will be downloaded. Next step is to upload malicious program to container and prepare the exploit. Let's execute the script:
-[source]
+. Execute the script to prepare the environment:
++
+----
 [root@selinux6 selinux_scripts]# ./runcescape.sh
 [+] Installing docker
 [+] Starting docker
 [+] Downloading container
 [+] Uploading exploit
 [+] Executing docker
+----
++
+Now, the container with the malicious program is ready and waiting for a system administrator to execute the program inside the container. In this case, the malicious program is renamed to `bash` and replaced with the real `/bin/bash`.
 
-. Now, container with malicious program is ready, and waiting for system administrator who will execute the program inside the container. In this case, malicious program is renamed to _bash_ and replaced with the real _/bin/bash_. Let's execute it inside the container:
-[source]
+. Start the Docker container, which executes the malicious program:
++
+----
 [root@selinux6 selinux_scripts]# docker exec -it pwnme /bin/bash
 [+] bad_libseccomp.so booted.
 [+] opened ro /proc/self/exe <3>.
 [+] constructed fdpath </proc/self/fd/3>
 [+] bad_init is ready -- see </tmp/bad_init_log> for logs.
 [*] dying to allow /proc/self/exe to be unused...
+----
++
+Due to the nature of the attack, it may be necessary to execute the last command multiple times to make sure the attack is successful.
 
-. Because of type of the attack, sometimes it's necessary to execute the last command multiple times, so to make sure the attack is successful execute the latest command _docker exec -it pwnme /bin/bash_ multiple times.
+. Execute the `docker exec -it pwnme /bin/bash` command multiple times.
 
-=== Lab 2.2.3 Analyzing the SELinux denial
+=== 2.3.3: Analyzing the SELinux Denial
 
-Let's analyze what happened and why SELinux blocked the runc escape exploit.
+In this section, you analyze what happened and why SELinux blocked the `runc` escape exploit.
 
-Run _ausearch_ command to see SELinux denial:
-[source]
+. Run the `ausearch` command to see the SELinux denial:
++
+----
 [root@selinux6 selinux_scripts]# ausearch -m AVC -ts today | grep container_runtime_exec_t
 type=AVC msg=audit(1554464510.001:479): avc:  denied  { write } for  pid=5190 comm="bad_init" name="docker-runc-current" dev="dm-0" ino=9162730 scontext=system_u:system_r:container_t:s0:c915,c946 tcontext=system_u:object_r:container_runtime_exec_t:s0 tclass=file permissive=0
+----
++
+This is the AVC record from the *audit* daemon. It says that a malicious process inside the *bad_init* container (labeled `container_t`) is trying to modify the *docker-runc-current* container (labeled as `container_runtime_exec_t`) on the host system. SELinux blocked this clearly malicious behavor.
 
-This is the avc record from the Audit daemon. This output is saying that malicious process inside the container *bad_init* labeled as *container_t* is trying to modify *docker-runc-current* labeled as *container_runtime_exec_t* on host system. This is clearly not good and should be blocked, what SELinux did.
+=== 2.3.4: Repeating the Attack in Permissive Mode
 
-=== Lab 2.2.4 Set SELinux to permissive mode
+The *selinux6* system has been running SELinux in enforcing mode. In this section, you switch SELinux to permissive mode and then you repeat the attack with SELinux in permissive mode.
 
-The _selinux6_ system has SELinux in enforcing mode. Now, let's switch SELinux to permissive and repeat the attack.
-[source]
+. Switch SELinux to _permissive_ mode:
++
+----
 [root@selinux6 selinux_scripts]# setenforce 0
 [root@selinux6 selinux_scripts]# getenforce
 Permissive
+----
 
-==== Lab 2.2.5 exercise steps in permissive mode
-Now, let's follow these steps again to reproduce the attack in permissive mode.
-
-. First step is to prepare new container with the exploit
-[source]
+. First, prepare the new container with the exploit:
++
+----
 [root@selinux6 selinux_scripts]# ./runcescape.sh
 [+] Installing docker
 [+] Starting docker
 [+] Downloading container
 [+] Uploading exploit
 [+] Executing docker
+----
++
+The container with the malicious program is ready for the system administrator to execute it. In this case, the malicious program is renamed to _bash_ and replaced with the real `/bin/bash`.
 
-. Now, container with malicious program is ready, and waiting for system administrator who will execute the program inside the container. In this case, malicious program is renamed to _bash_ and replaced with the real _/bin/bash_. Let's repeat the attack, now it will be successful because SELinux is in permissive mode.
-[source]
+. Repeat the attack and, because SELinux is in permissive mode, expect it to be successful:
++
+----
 [root@selinux6 selinux_scripts]# docker exec -it pwnme /bin/bash
 [+] bad_libseccomp.so booted.
 [+] opened ro /proc/self/exe <3>.
 [+] constructed fdpath </proc/self/fd/3>
 [+] bad_init is ready -- see </tmp/bad_init_log> for logs.
 [*] dying to allow /proc/self/exe to be unused...
+----
++
+Because of the nature of the attack, it is sometimes necessary to execute the last command multiple times to make sure the attack is successful.
 
-. Because of type of the attack, sometimes it's necessary to execute the last command multiple times, so to make sure the attack is successful execute the latest command _docker exec -it pwnme /bin/bash_ multiple until you'll see this output:
-[source]
+. Execute the last command (`docker exec -it pwnme /bin/bash`) multiple times until you see this output:
++
+----
 [root@selinux6 selinux_scripts]# docker exec -it pwnme /bin/bash
 rpc error: code = 2 desc = containerd: container not started
+----
++
+This proves that exploit was successful.
 
-This is a proof that exploit was successful. Output of command _ausearch -m AVC -ts today_ will again show same SELinux denial, like in Enforcing but because we're in permissive also payload of exploit is executed. In our case, payload creates file in root filesystem with name *HACKED*. Let's prove it:
-[source]
+. Run the `ausearch -m AVC -ts today` command again and note that it shows the same SELinux denial as it did in enforcing mode--but because the machine is in permissive mode, the payload of the exploit is also executed.
+
+. Determine that the exploit actually worked:
++
+----
 [root@selinux6 selinux_scripts]# cd /
 [root@selinux6 /]# ls
 bin   dev  HACKED  lib    media  opt   root  sbin  sys  usr
 boot  etc  home    lib64  mnt    proc  run   srv   tmp  var
+----
++
+The payload creates a file named `HACKED` in the root file system.
++
+Note the `HACKED` file. This is simply an example--a real exploit, rather than merely creating a file in the `/` directory, would have allowed arbitrary and far more dangerous code execution as *root*.
 
-File with name *HACKED* is there. Of course, this is just an example, instead of creating file in /, there can be arbitary code execution.
+== 2.4: Enabling SELinux via Ansible
 
-== Lab 2.3 Enabling SELinux via Ansible
+SELinux brings additional security to an environment and often needs to be modified to reflect the current environment configuration. In such cases, SELinux can be switched during debugging to permissive mode so that it does not block the basic functionality of the system. In permissive mode, you can run the system for some time to debug all possible SELinux AVC denials. Once you have adjusted the rules to handle all of the desired functionality, you can switch SELinux back to enforcing mode.
 
-=== Goal of Lab 2.3
+There are many ways to view or modify the installed SELinux policy. In this section, you use the SELinux Ansible role to distribute all of the required changes in the SELinux policy to make your Apache configuration work with SELinux in enforcing mode.
 
-SELinux brings additional security for your environment and very often needs to be further modified to reflect the current environment configuration. For these cases, SELinux can be switched to Permissive mode as a debugging mode to not block basic functionality of systems. With this mode, we can run for a time period to debug all possible SELinux AVC denials, which makes turning SELinux on easier to manage. There are many ways to view or modify the installed SELinux policy.
+More specifically, you enable SELinux in your environment, which consists of an Apache server using both custom and standard paths for web files, so that the Apache server is fully confined by SELinux. You do this by using the SELinux system roles feature as an Ansible role to configure SELinux in an automated fashion.
 
-In this lab, we used the SELinux Ansible role to distribute all needed changes in the SELinux policy to make our Apache configuration working with SELinux in Enforcing mode.
+=== 2.4.1: Setting Up Environment
 
-Specifically, in this lab exercise, you will enable SELinux in your environment, which consists of an Apache server using both custom and standard paths for web files. You will enable SELinux so that your Apache server is fully confined by SELinux. Specifically, you will use the SELinux system roles feature as an Ansible role to configure SELinux in an automated fashion.
+In this section, you have an environment with Apache web servers, where both default and custom paths for Apache web files are used. Specifically:
 
-=== Introduction and Lab Background Info
+ * `/var/www/html` (default)
+ * `/var/www_new/html` (custom)
 
-In this lab exercise, you have an environment with Apache web servers,  where both default and custom paths for Apache web files are used. Specifically:
+These web files are accessible using *TCP/80* and *TCP/7070* ports on each web server:
 
- * /var/www/html (default)
- * /var/www_new/html (custom)
+ * *selinux2.example.com:80* (default)
+ * *selinux2.example.com:7070* (custom)
 
-These web files are accessible using tcp/80 and tcp/7070 ports on each web server.
+ * *selinux3.example.com:80* (default)
+ * *selinux3.example.com:7070* (custom)
 
- * selinux2.example.com:80 (default)
- * selinux2.example.com:7070 (custom)
+ * *selinux5.example.com:80* (default)
+ * *selinux5.example.com:7070* (custom)
 
- * selinux3.example.com:80 (default)
- * selinux3.example.com:7070 (custom)
-
- * selinux5.example.com:80 (default)
- * selinux5.example.com:7070 (custom)
-
-SELinux is disabled for all web servers by default. In a fully automated fashion, you will turn SELinux on for all web servers without breaking any functionality using the SELinux system roles feature as an Ansible role.
+By default, SELinux is disabled for all web servers. In a fully automated fashion, you turn SELinux on for all web servers without breaking any functionality using the SELinux system roles feature as an Ansible role.
 
 The SELinux part of the lab environment consists of four machines:
 
- * selinux1, selinux1.example.com (RHEL-8 admin host)
- * selinux2, selinux2.example.com (RHEL-8 host)
- * selinux3, selinux3.example.com (RHEL-6 host)
- * selinux5, selinux5.example.com (RHEL-7 host)
+ * *selinux1*, *selinux1.example.com* (RHEL-8 admin host)
+ * *selinux2*, *selinux2.example.com* (RHEL-8 host)
+ * *selinux3*, *selinux3.example.com* (RHEL-6 host)
+ * *selinux5*, *selinux5.example.com* (RHEL-7 host)
 
-The first _selinux1.example.com_ host will be used as an admin interface to setup the other two hosts where we will complete all our configuration steps.
+The first *selinux1.example.com* host is used as an administrative interface to set up the other hosts, where you complete all of the configuration steps.
 
-===  Pre-Configured Set Up Steps (Already done for you)
+=== 2.4.2: Reviewing Setup Steps (Preconfigured)
 
-*Important*: All steps in this _Pre-Configured Set Up Steps_ section have been already performed in the lab environment for you. They are mentioned from an informative purpose and they ONLY need to executed if you use the revert script for this lab
+[IMPORTANT]
+All of the steps in this _Setup Steps_ section have already been performed in the lab environment for you. They are described here for informative purposes, and must be executed _only_ if you use the revert script for this lab.
 
-==== Viewing basic environment pre-configuration information
+==== 2.4.2.1: Viewing Basic Preconfigured Environment
 
-Let's take a look at what has been pre-configured for you in this part of the lab exercise.
+In this section, you explore what is already configured for you in this part of the lab.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. If not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
+----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
 
-. Log into the _selinux1.example.com_ system as *root*.
+. Log in to the *selinux1.example.com* system as *root*:
 +
-[source]
+----
 [lab-user@workstation-GUID ~]# ssh root@selinux1.example.com
+----
 
-. Look at the DNS records on the _selinux1_ server.
-[source]
+. Look at the DNS records on the *selinux1* server:
++
+----
 [root@selinux1 ~]# cat /etc/hosts
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 192.168.0.20 selinux2
 192.168.0.21 selinux3
 192.168.0.6 selinux5
+----
 
-.  The __ansible__ package has been installed on the _selinux1_ host.
-[source]
+. Install Ansible if it is not already installed on the *selinux1* host:
++
+----
 [root@selinux1 ~]# pip3 install ansible
+----
 
-. Enter the _selinux_scripts_ working directory on the _selinux1_ host.
-[source]
+. Change to the `selinux_scripts` working directory on the *selinux1* host:
++
+----
 [root@selinux1 ~]# cd /root/selinux_scripts
+----
 
-. Look at the created inventory file for our Ansible usage.
-[source]
+. Look at the created inventory file for your Ansible usage:
++
+----
 [root@selinux1 selinux_scripts]# cat inventory
 selinux2 ansible_python_interpreter=/usr/libexec/platform-python
 selinux3
 selinux5
+----
 
-==== Pre-Configuration of Apache web servers with SELinux disabled
+==== 2.4.2.2: Testing Preconfigured Apache Web Servers with SELinux Disabled
 
-The _apache_ web servers were set up using the _setup-webserver.yml_ playbook and this playbook was executed on the _selinux2_,  _selinux3_ and _selinux5_ hosts.  SELinux was also turned off.
+The Apache web servers are already set up using the `setup-webserver.yml` playbook, which was executed on the *selinux2*, *selinux3*, and *selinux5* hosts. SELinux is also turned off.
 
-All ansible commands below were executed from _selinux1.example.com_.
+All of the Ansible commands in this section were executed from *selinux1.example.com*.
 
-Test whether all servers are available via the _ansible_ command.
+In this section, you test whether all of the servers are available via the `ansible` command.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. If not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
+----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
 
-. If not already root, become *root* and then log into the _selinux1.example.com_ system.
+. If you are not already *root*, become *root* and then log in to the *selinux1.example.com* system:
 +
-[source]
+----
 [lab-user@workstation-GUID ~]# ssh root@selinux1.example.com
+----
 
-. Enter the _selinux_scripts_ working directory on the _selinux1_ host.
-[source]
-[root@selinux1 ~]# cd /root/selinux_scripts
-
-. Now let's test which servers are accessible.
+. Change to the `selinux_scripts` working directory on the *selinux1* host:
 +
-[source]
+----
+[root@selinux1 ~]# cd /root/selinux_scripts
+----
+
+. Test which servers are accessible:
++
+----
 [root@selinux1 selinux_scripts]# ansible all -i inventory -m ping -u root
-
-. An Ansible script will pass all listed servers in the _inventory_ file and will send a test to see if they are accessible. All servers should return a pong response.
-
+----
++
+This Ansible invocation specifies all listed servers in the _inventory_ file and tests to see if they are accessible. Accessible servers return the `pong` response:
++
+----
     selinux3 | SUCCESS => {
         "changed": false,
         "ping": "pong"
@@ -421,82 +486,107 @@ Test whether all servers are available via the _ansible_ command.
         "changed": false,
         "ping": "pong"
     }
+----
 
-. Apache web servers were configured on given servers via the _setup_webserver.yml_ playbook.
-
-	[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root setup-webserver.yml
-
-The following actions were performed for all hosts mentioned in the _inventory_ file:
-
- * SELinux was disabled.
- * Apache webservers were
-  ** installed
-  ** configured to listen on _tcp/80_ and _tcp/7070_ ports via the _linux-sytem-roles/firewall_ ansible role.
-  ** configured to use two root directories for web files,
-
-	/var/www/html (default)
-	/var/www_new/html (custom)
-
-  ** were rebooted,
-
-At the end we installed the _setools-console_ package containing SELinux policy query tools which will be used for SELinux Troubleshooting.
-
-	[root@selinux1 selinux_scripts]# ssh root@selinux2 yum install setools-console -y
-
-	[root@selinux1 selinux_scripts]# ssh root@selinux3 yum install setools-console -y
-
-	[root@selinux1 selinux_scripts]# ssh root@selinux5 yum install setools-console -y
-
-=== Lab 2.3.1 Testing the pre-configured setup
-In this section, we are going to test our pre-configured setup steps from before.
-
-	[root@selinux1 selinux_scripts]# hostname
-	selinux1.example.com
-
-	[root@selinux1 selinux_scripts]# cd /root/selinux_scripts
-
-	[root@selinux1 selinux_scripts]# curl selinux{2,3,5}
-	<h1>Default Document Root</h1>
-	<h1>Default Document Root</h1>
-	<h1>Default Document Root</h1>
-
-	[root@selinux1 selinux_scripts]# curl selinux{2,3,5}:7070
-	<h1>Custom Document Root</h1>
-	<h1>Custom Document Root</h1>
-	<h1>Custom Document Root</h1>
-
-	[root@selinux1 selinux_scripts]# ssh root@selinux2 getenforce
-	Disabled
-
-    [root@selinux1 selinux_scripts]# ssh root@selinux3 getenforce
-	Disabled
-
-    [root@selinux1 selinux_scripts]# ssh root@selinux5 getenforce
-	Disabled
-
-
-=== Lab 2.3.2 Turning SELinux On
-
-. Setup SELinux to _permissive_ mode and relabel the whole filesystem.
-
-	[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root enable-selinux.yml
-
-
-. SELinux is switched to _permissive_ mode using the _enable-selinux_ playbook. It means that SELinux policy is enabled but is not enforced. We can use the _getenforce_ and _sestatus_ utility to view the current SELinux mode for our server(s).
-
-    [root@selinux1 selinux_scripts]# ssh root@selinux2 getenforce
-    [root@selinux1 selinux_scripts]# ssh root@selinux2 sestatus
-
-. SELinux does not deny access, but denials are logged for actions that would have been denied if running in enforcing mode. In order to show logged denials for certain actions we need to run the _curl_ command. AVC denial(s) will be generated and we can view it via the _ausearch_ command below.
-
+. Configure Apache web servers on the given servers via the `setup_webserver.yml` playbook:
 +
-[source,text]
+----
+[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root setup-webserver.yml
+----
++
+This playbook performs the following actions for all of the hosts mentioned in the `inventory` file:
+
+* SELinux is disabled.
+* Apache web servers are:
+** Installed
+** Configured to listen on ports *TCP/80* and *TCP/7070* via the *linux-sytem-roles/firewall* Ansible role
+** Configured to use `/var/www/html` (default) and `/var/www_new/html` (custom) as root directories
+** Rebooted
+
+. Install the `setools-console` package containing SELinux policy query tools, which is used for SELinux troubleshooting:
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux2 yum install setools-console -y
+
+[root@selinux1 selinux_scripts]# ssh root@selinux3 yum install setools-console -y
+
+[root@selinux1 selinux_scripts]# ssh root@selinux5 yum install setools-console -y
+----
+
+
+=== 2.4.3: Testing the Preconfigured Setup
+
+. Test the preconfigured setup steps:
++
+----
+[root@selinux1 selinux_scripts]# hostname
+selinux1.example.com
+----
++
+----
+[root@selinux1 selinux_scripts]# cd /root/selinux_scripts
+----
++
+----
+[root@selinux1 selinux_scripts]# curl selinux{2,3,5}
+<h1>Default Document Root</h1>
+<h1>Default Document Root</h1>
+<h1>Default Document Root</h1>
+----
++
 ----
 [root@selinux1 selinux_scripts]# curl selinux{2,3,5}:7070
 <h1>Custom Document Root</h1>
 <h1>Custom Document Root</h1>
 <h1>Custom Document Root</h1>
+----
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux2 getenforce
+Disabled
+----
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux3 getenforce
+Disabled
+----
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux5 getenforce
+Disabled
+----
 
+=== 2.4.4: Turning SELinux On
+
+. Set SELinux to _permissive_ mode and relabel the entire file system:
++
+----
+[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root enable-selinux.yml
+----
++
+SELinux is switched to _permissive_ mode using the `enable-selinux` playbook. This means that SELinux policy is enabled but not enforced.
+
+. Use `getenforce` and `sestatus` to view the current SELinux mode for your servers:
++
+----
+[root@selinux1 selinux_scripts]# ssh root@selinux2 getenforce
+[root@selinux1 selinux_scripts]# ssh root@selinux2 sestatus
+----
++
+SELinux does not deny access, but denials are logged for actions that would have been denied had SELinux been running in enforcing mode.
+
+. Run the `curl` command to show logged denials for certain actions:
++
+----
+[root@selinux1 selinux_scripts]# curl selinux{2,3,5}:7070
+<h1>Custom Document Root</h1>
+<h1>Custom Document Root</h1>
+<h1>Custom Document Root</h1>
+----
+
+. Note that AVC denials are generated and and view the denials using the `ausearch`:
++
+----
 [root@selinux1 selinux_scripts]# ssh root@selinux2
 
 [root@selinux2 ~]# ausearch -m AVC -su httpd_t -ts recent
@@ -508,61 +598,78 @@ avc:  denied  { open } for  pid=778 comm="httpd" path="/var/www_new/html/index.h
 avc:  denied  { getattr } for  pid=778 comm="httpd" path="/var/www_new/html/index.html" dev="dm-0" ino=8751871 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:var_t:s0 tclass=file permissive=1
 ----
 
-=== Lab 2.3.3 SELinux Troubleshooting
-In the previous step, we turned SELinux on and got AVC denials. Denial messages are logged when SELinux denies access. Let's find out why we got these AVC denials.
+=== 2.4.5: SELinux Troubleshooting
+In the previous section, you enabled SELinux and AVC denials occurred. Denial messages are logged when SELinux denies access. In this section, you investigate why these denials occurred.
 
-SELinux Troubleshooting can be performed on both the _selinux2_ and _selinux3_ hosts. We will use the _selinux2_ host for the following examples.
+SELinux troubleshooting can be performed on both the *selinux2* and *selinux3* hosts. You use the *selinux2* host in the following examples.
 
-. Log into the _selinux2_ host, if you're not already logged in.
-
-	[root@selinux1 selinux_scripts]# ssh root@selinux2
-
-==== Lab 2.3.3.1 SELinux Port
-
-. SELinux _httpd_t_ process domain used for Apache web servers is not able to bind to _tcp/7070_ port by default. There is no default rule for this access in the SELinux policy on the RHEL-7 _selinux5_ and RHEL-8 _selinux2_ hosts.
-
-  [root@selinux2 ~]# sesearch -A -s httpd_t -t unreserved_port_t -c tcp_socket -p name_bind | grep httpd_t
-
-. Compare to that Apache webservers can bind to other ports and these SELinux port types can be assigned to our selected custom port (_tcp/7070_).
-
-  [root@selinux2 ~]# sesearch -A -s httpd_t -c tcp_socket -p name_bind | grep httpd_t
-
-==== Lab 2.3.3.2 SELinux File context
-
-. SELinux _httpd_t_ process domain used for Apache webservers is not able to read a general _/var_ content with SELinux _var_t_ file type. There is no rule for this access in the SELinux policy.
-
-	[root@selinux2 ~]# sesearch -A -s httpd_t -t var_t -c file -p read
-
-. Compare to that Apache webservers can read a specific content with a specific SELinux file type.
-
-	[root@selinux2 ~]# sesearch -A -s httpd_t -c file -p read
-
-. We can use the matchpathcon utility to decide what should be a proper context for our alternative location for web files.
-
-	[root@selinux2 ~]# matchpathcon /var/www/html
-	/var/www/html    system_u:object_r:httpd_sys_content_t:s0
-	[root@selinux2 ~]# exit
-
-=== Lab 2.3.4 Viewing and Executing the SELinux _setup-selinux.yml_ ansible playbook
-
-We will execute an SELinux Ansible playbook which will switch SELinux to Enforcing mode and apply all needed changes for our web servers' configuration.
-
-The playbook uses the linux-system-roles/selinux Ansible role.
-
-Let's take a quick look at this Ansible playbook.
-
-. Make sure you are on the *selinux1* system and navigate to the /root/selinux_scripts directory.
-
-	[root@selinux1 selinux_scripts]# hostname
-	selinux1.example.com
-
-	[root@selinux1 selinux_scripts]# pwd
-	/root/selinux_scripts
-
-. Open the *setup-selinux.yml* Ansible playbook.
-
-  [root@selinux1 selinux_scripts]# cat setup-selinux.yml
+. Log in to the *selinux2* host, if you are not already logged in:
++
 ----
+[root@selinux1 selinux_scripts]# ssh root@selinux2
+----
+
+==== 2.4.5.1: Checking SELinux Port
+
+. Verify that SELinux `httpd_t` process domain used for Apache web servers is not able to bind to *TCP/7070* port by default:
++
+----
+[root@selinux2 ~]# sesearch -A -s httpd_t -t unreserved_port_t -c tcp_socket -p name_bind | grep httpd_t
+----
++
+There is no default rule for this access in the SELinux policy on the RHEL-7 *selinux5* and RHEL-8 *selinux2* hosts.
+
+. Verify that Apache web servers _can_ bind to other ports and these SELinux port types can be assigned to your selected custom port (*TCP/7070*):
++
+----
+[root@selinux2 ~]# sesearch -A -s httpd_t -c tcp_socket -p name_bind | grep httpd_t
+----
+
+==== 2.4.5.2: Checking SELinux File Context
+
+The SELinux `httpd_t` process domain used for Apache web servers is not able to read a general `/var` content with the SELinux `var_t` file type.
+
+. Verify that there is no rule for this access in the SELinux policy:
++
+----
+[root@selinux2 ~]# sesearch -A -s httpd_t -t var_t -c file -p read
+----
+
+. Verify that Apache web servers can read a specific content with a specific SELinux file type:
++
+----
+[root@selinux2 ~]# sesearch -A -s httpd_t -c file -p read
+----
+
+. Use the `matchpathcon` utility to decide the proper context for your alternate location for web files:
++
+----
+[root@selinux2 ~]# matchpathcon /var/www/html
+/var/www/html    system_u:object_r:httpd_sys_content_t:s0
+[root@selinux2 ~]# exit
+----
+
+=== 2.4.6: Viewing and Executing the SELinux `setup-selinux.yml` Ansible Playbook
+
+In this section, you examine and then execute an Ansible Playbook that switches SELinux to enforcing mode and applies all of the required changes for your web servers' configurations.
+
+The playbook uses the `linux-system-roles/selinux Ansible` role.
+
+. Make sure that you are on the *selinux1* system, then navigate to the `/root/selinux_scripts` directory:
++
+----
+[root@selinux1 selinux_scripts]# hostname
+selinux1.example.com
+
+[root@selinux1 selinux_scripts]# pwd
+/root/selinux_scripts
+----
+
+. Open the `setup-selinux.yml` Ansible Playbook to take a closer look at it:
++
+----
+[root@selinux1 selinux_scripts]# cat setup-selinux.yml
+
   - hosts: all
   become: true
   become_user: root
@@ -580,297 +687,426 @@ Let's take a quick look at this Ansible playbook.
   roles:
     - linux-system-roles.selinux
 ----
-
-. Let's take a closer look at the _setup_selinux.yml_ Ansible playbook.
-
-* In the _vars_ section, we are switching SELinux to Enforcing mode.
-
++
+In the `vars` section, you switch SELinux to enforcing mode:
++
+----
     SELinux_type: targeted
     SELinux_mode: enforcing
     SELinux_change_running: 1
-
-* Webservers use the custom _/var/www_new/html_ path for web pages. SELinux labels have to be fixed for this directory and sub directories/files to reflect the default SELinux security labels for the _/var/www/html_ location. It is ensured by the following lines in the playbook:
-
+----
++
+Web servers use the custom `/var/www_new/html` path for web pages. SELinux labels must be fixed for this directory and subdirectories/files to reflect the default SELinux security labels for the `/var/www/html` location. This is done by the following lines in the playbook:
++
+----
     SELinux_file_contexts:
         - { target: '/var/www_new(/.*)?', setype: 'httpd_sys_content_t', ftype: 'a' }
-
-* Once SELinux security labels are defined in the SELinux context database, these labels should be applied into extended attributes of selected files.  It is ensured by the following lines in the playbook:
-
+----
++
+After SELinux security labels are defined in the SELinux context database, these labels must be applied into extended attributes of selected files as done by these lines in the playbook:
++
+----
     SELinux_restore_dirs:
         - /var/www_new
-
-* All web servers are binded to the custom _tcp/7070_ port in our configuration. This setup needs to be reflected in a SELinux configuration. It is ensured by the following lines in the playbook:
-
+----
++
+All web servers are bound to the custom *TCP/7070* port in the configuration. This setup must be reflected in a SELinux configuration as done in these lines of the playbook:
++
+----
     SELinux_ports:
         - { ports: '7070', proto: 'tcp', setype: 'http_port_t', state: 'present' }
+----
 
-. Now let's execute this _setup_selinux.yml_ Ansible playbook and apply these defined configurations for all servers.
+. Execute the `setup_selinux.yml` Ansible Playbook and apply these defined configurations for all of the servers:
++
+----
+[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root setup-selinux.yml
+----
 
-    [root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root setup-selinux.yml
 
-=== Lab 2.3.5 Viewing all SELinux configuration changes
+=== 2.4.7: Viewing SELinux Configuration Changes
 
-. Now let's test and view all our recent SELinux configuration changes.
+. Test and view all of the recent SELinux configuration changes:
++
+----
+[root@selinux1 selinux_scripts]# ssh selinux2 semanage export
 
-    [root@selinux1 selinux_scripts]# ssh selinux2 semanage export
+[root@selinux1 selinux_scripts]# ssh selinux5 semanage export
 
-    [root@selinux1 selinux_scripts]# ssh selinux5 semanage export
+[root@selinux1 selinux_scripts]# ssh selinux3 semanage -o -
+----
 
-    [root@selinux1 selinux_scripts]# ssh selinux3 semanage -o -
+. Determine the current SELinux status for all of the servers:
++
+----
+[root@selinux1 selinux_scripts]# ansible all -i inventory -u root -a getenforce
+----
 
-. Check the current SELinux status for all servers..
-
-    [root@selinux1 selinux_scripts]# ansible all -i inventory -u root -a getenforce
-
-. Check the functionality with enabled SELinux.
-
+. Check the functionality with SELinux enabled:
++
+----
     [root@selinux1 selinux_scripts]# curl selinux{2,3,5}
 	<h1>Default Document Root</h1>
 	<h1>Default Document Root</h1>
 	<h1>Default Document Root</h1>
-
+----
++
+----
     [root@selinux1 selinux_scripts]# curl selinux{2,3,5}:7070
 	<h1>Custom Document Root</h1>
 	<h1>Custom Document Root</h1>
 	<h1>Custom Document Root</h1>
+----
 
-== Revert script
+=== 2.4.8: Reverting Script
 
-This step is required for the next lab exercise.
+This `revert` script is needed to proceed to the next lab section (or if you plan to repeat the lab again from the beginning). Additionally, all of the steps in the _Setup Steps_ section mentioned in the beginning of this lab must be executed, with the exception of the package installation steps.
 
-Also, for those of you that want to re-do this lab exercise from the beginning, you can run this revert script. All the steps in the _Pre-Configured Set-Up_ steps section mentioned in the beginning of this lab will need to be executed , with the exception of the package installation steps.
+In this section, you invoke the `revert` script.
 
-    [root@selinux1 selinux_scripts]# hostname
-    selinux1.example.com
-
-    [root@selinux1 selinux_scripts]# pwd
-    /root/selinux_scripts
-
-    [root@selinux1 selinux_scripts]# cat inventory
-    selinux2 ansible_python_interpreter=/usr/libexec/platform-python
-    selinux3
-    selinux5
-
-    [root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root revert-all.yml
-
-== Lab 2.4 How to set up a system with SELinux confined users
-
-=== Goal of Lab 2.4
-As an enterprise system administrator, I may want my systems to follow the US Department of Defense STIG security rule V-71971 so that my system will be fully confined without unconfined users.
-I also would only want one administrator user who can become root and manage the system, and limit the access of other users.
-
-This lab exercise is split into three steps:
-
-. Confine regular Linux users
-. Confine Linux root users
-. Revert script
-
-=== Introduction
-In Red Hat Enterprise Linux, Linux users are mapped to the SELinux _unconfined_u_ user by default. All processes run by _unconfined_u_ are in the _unconfined_t_ domain. This means that users can access across the system within the limits of the standard Linux DAC policy. However, a number of confined SELinux users are available in Red Hat Enterprise Linux. This means that users can be restricted to limited set of capabilities. Each Linux user is mapped to an SELinux user using SELinux policy, allowing Linux users to inherit the restrictions placed on SELinux users.
-
-=== Lab 2.4.1 Confine regular Linux users
-
-. Make sure that the "revert script" from previous step was executed.
-
-    [root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root revert-all.yml
-
-. All actions are performed on the _selinux5_ host , which is a RHEL 7.5 system.
-
-. If not already there, log into to the bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. Run the `revert` script:
 +
-[source]
+----
+[root@selinux1 selinux_scripts]# hostname
+selinux1.example.com
+
+[root@selinux1 selinux_scripts]# pwd
+/root/selinux_scripts
+
+[root@selinux1 selinux_scripts]# cat inventory
+selinux2 ansible_python_interpreter=/usr/libexec/platform-python
+selinux3
+selinux5
+
+[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root revert-all.yml
+----
+
+== 2.5: Setting Up a System with SELinux Confined Users
+
+As an enterprise system administrator, you may want your systems to follow the U.S. Department of Defense STIG security rule V-71971 so that your system is fully confined without unconfined users.
+In addition, you may want to have only one administrator user who can become *root* and manage the system, and to limit the access of other users.
+
+In Red Hat Enterprise Linux, Linux users are mapped to the SELinux `unconfined_u` user by default. All of the processes run by `unconfined_u` are in the `unconfined_t` domain. This means that users can access the system within the limits of the standard Linux DAC policy. However, a number of _confined_ SELinux users are available in Red Hat Enterprise Linux. This means that users can be restricted to a limited set of capabilities. Each Linux user is mapped to an SELinux user using SELinux policy, allowing Linux users to inherit the restrictions placed on SELinux users.
+
+This lab section is comprised of three key parts:
+
+* Confining regular Linux users
+* Confining Linux root users
+* Using the revert script
+
+=== 2.5.1: Confining Regular Linux Users
+
+. Execute the `revert` script if you did not do this in the previous section:
++
+----
+[root@selinux1 selinux_scripts]# ansible-playbook -i inventory -u root revert-all.yml
+----
++
+All actions are performed on the *selinux5* host, which is a RHEL 7.5 system.
+
+. If you are not already there, log in to the bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
++
+----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
 
-. Log into the _selinux1.example.com_ system as root.
+. Log in to the *selinux1.example.com* system as *root*, then SSH to *selinux5.example.com* as *root*:
 +
-[source]
+----
 [lab-user@workstation-GUID ~]# ssh root@selinux1.example.com
 [root@selinux1 ~]# ssh root@selinux5.example.com
+----
 
-. Linux users can be assigned to SELinux users using semanage login tool. By default users are mapped to _unconfined_u_:
-
-    [root@selinux5 ~]# semanage login -l
-
-==== Lab 2.4.1.1 Change the default mapping
-
-. In order to change mapping all Linux users we need to modify the record with __default__ which represents all users without explicit mapping.
-
-_system_u_ is a special user used only for system processes and in the future will not be listed.
-
-    [root@selinux5 ~]# semanage login -m -s user_u -r s0 __default__
-    [root@selinux5 ~]# semanage login -l
-
-==== Lab 2.4.1.2 Add a test user
-
-. After this, when users (not root) logs in, their processes will run the _user_t_ domain. Every user session but root will run with _user_t_:
-
-    [root@selinux5 ~]# adduser user42
-
-    [root@selinux5 ~]# passwd user42
-    (Feel free to pick whatever password you want for user42. But, be sure to pick a password you can remember.)
-
-    [root@selinux5 ~]# ssh user42@localhost
-    user42@localhost's password:
-    [user42@selinux5 ~]$ id -Z
-    user_u:user_r:user_t:s0
-
-    [user42@selinux5 ~]$ ps axZ
-    LABEL                     PID TTY    STAT  TIME COMMAND
-    -                           1 ?      Ss    0:00 /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    user_u:user_r:user_t:s0  2780 ?      S     0:00 sshd: user42@pts/1
-    user_u:user_r:user_t:s0  2781 pts/1  Ss    0:00 -bash
-    user_u:user_r:user_t:s0  2808 pts/1  R+    0:00 ps axZ
-
-    # exit
-
-. Now we can try if the user can become root.
-
-. Let's add this line to the /etc/sudoers.d/administrators file:
-user42  ALL=(ALL)       NOPASSWD: ALL
-
-    [root@selinux5 ~]# visudo -f /etc/sudoers.d/administrators
-
-. In the text editor, Press *i* to insert and copy and paste this line into the text editor:
+. Use the `semanage` login tool to assign Linux users to SELinux users:
 +
-  user42  ALL=(ALL)       NOPASSWD: ALL
+----
+[root@selinux5 ~]# semanage login -l
+----
++
+Users are mapped to `unconfined_u` by default.
 
-. Next, press *esc* and then press *:wq!* to save and exit.
-. Let's confirm our changes.
+==== 2.5.1.1: Changing the Default Mapping
 
-    [root@selinux5 ~]# grep user42 /etc/sudoers.d/administrators
-    user42  ALL=(ALL)       NOPASSWD: ALL
+. Modify the record with `+__default__+`, which represents all of the users without an explicit mapping, to change the mapping of all Linux users:
++
+----
+[root@selinux5 ~]# semanage login -m -s user_u -r s0 __default__
+[root@selinux5 ~]# semanage login -l
+----
++
+*system_u* is a special user used only for system processes and is not listed.
 
+==== 2.5.1.2: Adding a Test User
 
-    [root@selinux5 ~]# ssh user42@localhost
-    user42@localhost's password:
-    [user42@selinux5 ~]$ sudo -i
-    sudo: PERM_SUDOERS: setresuid(-1, 1, -1): Operation not permitted
-    sudo: no valid sudoers sources found, quitting
-    sudo: setresuid() [0, 0, 0] -> [1001, -1, -1]: Operation not permitted
-    sudo: unable to initialize policy plugin
+After this, when users who are not *root* log in, their processes run in the `user_t` domain.
 
-. And the same attempt in permissive mode:
+. Every user session, other than for *root*, runs with `user_t`:
++
+----
+[root@selinux5 ~]# adduser user42
+----
++
+----
+[root@selinux5 ~]# passwd user42
+----
++
+[TIP]
+====
+You can select any password for *user42*, but make sure you remember what it is.
+====
++
+----
+[root@selinux5 ~]# ssh user42@localhost
+user42@localhost's password:
+[user42@selinux5 ~]$ id -Z
+user_u:user_r:user_t:s0
+----
++
+----
+[user42@selinux5 ~]$ ps axZ
+LABEL                     PID TTY    STAT  TIME COMMAND
+-                           1 ?      Ss    0:00 /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+user_u:user_r:user_t:s0  2780 ?      S     0:00 sshd: user42@pts/1
+user_u:user_r:user_t:s0  2781 pts/1  Ss    0:00 -bash
+user_u:user_r:user_t:s0  2808 pts/1  R+    0:00 ps axZ
 
-    [user42@selinux5 ~]$ exit
-    [root@selinux5 ~]# id -Z
-    unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+# exit
+----
 
-    [root@selinux5 ~]# setenforce 0
-    [root@selinux5 ~]# ssh user42@localhost
+. Determine whether the user can become *root*.
 
-    user42@localhost's password:
-    [user42@selinux5 ~]$ sudo -i
-    [root@selinux5 ~]# id
-    uid=0(root) gid=0(root) groups=0(root) context=user_u:user_r:user_t:s0
+. Add this line to the `/etc/sudoers.d/administrators` file:
++
+----
+user42  ALL=(ALL)       NOPASSWD: ALL
+----
++
+----
+[root@selinux5 ~]# visudo -f /etc/sudoers.d/administrators
+----
 
-    [root@selinux5 ~]# id -Z
-    User_u:user_r:user_t:s0
+. In the text editor, copy and past this line:
++
+----
+user42  ALL=(ALL)       NOPASSWD: ALL
+----
++
+[TIP]
+====
+To insert the line, copy it and then press *i* to insert. To save and exit, press *esc* and then press *:wq!*.
+====
 
-    [root@selinux5 ~]# exit
+. Confirm your changes:
++
+----
+[root@selinux5 ~]# grep user42 /etc/sudoers.d/administrators
+user42  ALL=(ALL)       NOPASSWD: ALL
+----
++
+----
+[root@selinux5 ~]# ssh user42@localhost
+user42@localhost's password:
+----
++
+----
+[user42@selinux5 ~]$ sudo -i
+sudo: PERM_SUDOERS: setresuid(-1, 1, -1): Operation not permitted
+sudo: no valid sudoers sources found, quitting
+sudo: setresuid() [0, 0, 0] -> [1001, -1, -1]: Operation not permitted
+sudo: unable to initialize policy plugin
+----
 
-    [user42@selinux5 ~]$ exit
-    [root@selinux5 ~]# setenforce 1
+. Attempt the same in permissive mode:
++
+----
+[user42@selinux5 ~]$ exit
+[root@selinux5 ~]# id -Z
+unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+----
++
+----
+[root@selinux5 ~]# setenforce 0
+[root@selinux5 ~]# ssh user42@localhost
+user42@localhost's password:
+[user42@selinux5 ~]$ sudo -i
+[root@selinux5 ~]# id
+uid=0(root) gid=0(root) groups=0(root) context=user_u:user_r:user_t:s0
+----
++
+----
+[root@selinux5 ~]# id -Z
+User_u:user_r:user_t:s0
+----
++
+----
+[root@selinux5 ~]# exit
+----
++
+----
+[user42@selinux5 ~]$ exit
+[root@selinux5 ~]# setenforce 1
+----
++
+Because SELinux denials are not enforced in permissive mode, `user42` can become *root*. But you can see that the context stayed `user_t` and did not change to `unconfined_t`.
 
-Since SELinux denials are not enforced in permissive mode, _user42_ can become root but we can see that the context stayed _user_t_ and didn't change to _unconfined_t_.
+=== 2.5.2: Confining the Administrator
 
-=== Lab 2.4.2 Confined Administrator
+There are two basic methods for confining the administrator user:
 
-. There are two basic methods for confining the administator user:
+An administrator can be directly mapped to the `sysadm_u` SELinux user so that when that user logs in, the session is run with `sysadm_t` domain. Alternatively, you assign administrator users to `staff_u` and configure `sudo` so that specific users can gain the SELinux administrator role.
 
-* Administrator can be directly mapped to _sysadm_u_ SELinux user so that when such user logs in, the session will be run with _sysadm_t_ domain. In this case you need to enable the _ssh_sysadm_login_ SELinux boolean in order to allow users assigned _sysadm_u_ to login using ssh.
+. In this case, enable the `ssh_sysadm_login` SELinux boolean option to allow users assigned `sysadm_u` to log in using SSH:
++
+----
+[root@selinux5 ~]# semanage user -m -R "sysadm_r secadm_r" sysadm_u
+[root@selinux5 ~]# adduser -G wheel -Z sysadm_u admin1
+----
++
+----
+[root@selinux5 ~]# passwd admin1
+----
++
+[TIP]
+====
+You can select any password for *admin1*, but make sure you remember what it is.
+====
++
+----
+[root@selinux5 ~]# semanage login -l | grep admin
+admin1               sysadm_u             s0-s0:c0.c1023       *
+----
++
+----
+[root@selinux5 ~]# setsebool -P ssh_sysadm_login on
+[root@selinux5 ~]# ssh admin1@localhost
+----
++
+----
+[admin1@selinux5 ~]$ id -Z
+sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
+----
++
+----
+[admin1@selinux5 ~]$ sudo -i
+[sudo] password for admin1:
+----
++
+----
+[root@selinux5 ~]# id -Z
+sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
+----
 
-    [root@selinux5 ~]# semanage user -m -R "sysadm_r secadm_r" sysadm_u
-    [root@selinux5 ~]# adduser -G wheel -Z sysadm_u admin1
+. Perform the administrator's operation, which can be executed only by *admin* SELinux users:
++
+----
+[root@selinux5 ~]# systemctl restart sshd
+[root@selinux5 ~]# exit
+[admin1@selinux5 ~]# exit
+----
 
-    [root@selinux5 ~]# passwd admin1
-    (Feel free to pick whatever password you want for admin1. But, be sure to pick a password you can remember.)
+. Using the second approach, assign administrator users to `staff_u` and configure `sudo` so that specific users can gain the SELinux administrator role:
++
+----
+[root@selinux5 ~]# adduser -G wheel -Z staff_u admin2
+----
++
+----
+[root@selinux5 ~]# passwd admin2
+----
++
+[TIP]
+====
+You can select any password for *admin2*, but make sure you remember what it is.
+====
++
+----
+[root@selinux5 ~]# semanage login -l | grep admin
+admin1               sysadm_u             s0-s0:c0.c1023       *
+admin2               staff_u              s0-s0:c0.c1023       *
+----
++
+----
+[root@selinux5 ~]# ssh admin2@localhost
+[admin2@selinux5 ~]$ id -Z
+staff_u:staff_r:staff_t:s0-s0:c0.c1023
+----
++
+----
+[admin2@selinux5 ~]$ sudo -i
+[sudo] password for admin2:
+-bash: /root/.bash_profile: Permission denied
+-bash-4.2# id -Z
+staff_u:staff_r:staff_t:s0-s0:c0.c1023
+----
 
-    [root@selinux5 ~]# semanage login -l | grep admin
-    admin1               sysadm_u             s0-s0:c0.c1023       *
+. Perform the administrator's operation, which can be executed only by *admin* SELinux users:
++
+----
+-bash-4.2# systemctl restart sshd
+Failed to restart sshd.service: Access denied
+See system logs and 'systemctl status sshd.service' for details.
+-bash-4.2# exit
+[admin2@selinux5 ~]$ exit
+----
 
-    [root@selinux5 ~]# setsebool -P ssh_sysadm_login on
-    [root@selinux5 ~]# ssh admin1@localhost
+. Add the following rule to `sudoers` to allow the *admin2* user to gain the SELinux administrator role:
++
+----
+[root@selinux5 ~]# visudo -f /etc/sudoers.d/administrators
+----
 
-    [admin1@selinux5 ~]$ id -Z
-    sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
+. Append the following line to the end of the file:
++
+----
+admin2  ALL=(ALL)  TYPE=sysadm_t ROLE=sysadm_r    ALL
+admin2  ALL=(ALL)  TYPE=secadm_t ROLE=secadm_r /usr/sbin/semanage,/usr/sbin/semodule
+----
++
+[TIP]
+====
+In the `vi` text editor, press *o*, then copy and paste these lines into the buffer. Then press *esc* and then type *:wq!* to save and exit.
+====
 
-    [admin1@selinux5 ~]$ sudo -i
-    [sudo] password for admin1:
+. The *admin2* user can gain the administrator role using `sudo`:
++
+----
+[root@selinux5 ~]# ssh admin2@localhost
+[admin2@selinux5 ~]$ sudo -i
+[sudo] password for admin2:
+----
++
+----
+[root@selinux5 ~]# id -Z
+staff_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
+----
++
+----
+[root@selinux5 ~]# systemctl restart sshd
+[root@selinux5 ~]#
+----
++
+----
+[root@selinux5 ~]# exit
+[admin2@selinux5 ~]# exit
+----
 
+=== 2.5.3: Reverting Script
 
-    [root@selinux5 ~]# id -Z
-    sysadm_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
+In this section, you use a `revert` script to restore the default SELinux user's configuration.
 
-** Now we can try to perform admin's operation which can be executed only by admin SELinux users.
-
-    [root@selinux5 ~]# systemctl restart sshd
-    [root@selinux5 ~]# exit
-    [admin1@selinux5 ~]# exit
-
-* The other way is to assign u administer users to _staff_u_ and configure _sudo_ so that particular users can gain SELinux administrator role.
-
-    [root@selinux5 ~]# adduser -G wheel -Z staff_u admin2
-
-    [root@selinux5 ~]# passwd admin2
-    (Feel free to pick whatever password you want for admin1. But, be sure to pick a password you can remember.)
-
-    [root@selinux5 ~]# semanage login -l | grep admin
-    admin1               sysadm_u             s0-s0:c0.c1023       *
-    admin2               staff_u              s0-s0:c0.c1023       *
-
-
-    [root@selinux5 ~]# ssh admin2@localhost
-    [admin2@selinux5 ~]$ id -Z
-    staff_u:staff_r:staff_t:s0-s0:c0.c1023
-
-    [admin2@selinux5 ~]$ sudo -i
-    [sudo] password for admin2:
-    -bash: /root/.bash_profile: Permission denied
-    -bash-4.2# id -Z
-    staff_u:staff_r:staff_t:s0-s0:c0.c1023
-
-
-. Now we can again try to perform administrator's operation which can be executed only by administrator SELinux users.
-
-    -bash-4.2# systemctl restart sshd
-    Failed to restart sshd.service: Access denied
-    See system logs and 'systemctl status sshd.service' for details.
-    -bash-4.2# exit
-    [admin2@selinux5 ~]$ exit
-
-. To allow admin2 user to gain SELinux administrator role you need to add the following rule to sudoers.
-
-    [root@selinux5 ~]# visudo -f /etc/sudoers.d/administrators
-
-. Append following line to end of file.  In the text editor, Press *o* then copy and paste these lines below into the text editor. Then, press *esc* and then press *:wq!* to save and exit.
-
-    admin2  ALL=(ALL)  TYPE=sysadm_t ROLE=sysadm_r    ALL
-    admin2  ALL=(ALL)  TYPE=secadm_t ROLE=secadm_r /usr/sbin/semanage,/usr/sbin/semodule
-
-. Admin2 can gain administrator role using sudo now.
-
-    [root@selinux5 ~]# ssh admin2@localhost
-    [admin2@selinux5 ~]$ sudo -i
-    [sudo] password for admin2:
-
-    [root@selinux5 ~]# id -Z
-    staff_u:sysadm_r:sysadm_t:s0-s0:c0.c1023
-
-    [root@selinux5 ~]# systemctl restart sshd
-    [root@selinux5 ~]#
-
-    [root@selinux5 ~]# exit
-    [admin2@selinux5 ~]# exit
-
-== Revert script
-
-There is a revert script to restore the default SELinux Users configuration. If you want to run this revert script, run it on the _selinux5_ host.
-
-    [root@selinux5 ~]# hostname
-    selinux5.example.com
-
-    [root@selinux5 ~]# cd /root
-    [root@selinux5 ~]# sh confined_users_revert.sh
+. (Optional) Run this `revert` script on the *selinux5* host:
++
+----
+[root@selinux5 ~]# hostname
+selinux5.example.com
+----
++
+----
+[root@selinux5 ~]# cd /root
+[root@selinux5 ~]# sh confined_users_revert.sh
+----
 
 <<top>>
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab3_NBDE.adoc[Lab 3: NBDE]
+
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab3_NBDE.adoc[Lab 3: NBDE^]
+

--- a/2020Labs/RHELSecurity/documentation/lab3_NBDE.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab3_NBDE.adoc
@@ -1,80 +1,116 @@
-= Lab 3: How to use Network Bound Disk Encryption (NBDE) to securely decrypt LUKS encrypted volumes
+:toc2:
 
-*Lab Length: Medium/Average (~15 mins)*
+= Lab 3: Secure Decryption of LUKS-Encrypted Volumes Using Network Bound Disk Encryption (NBDE)
 
-== Goal of Lab
-The goal of this lab is to understand how to use Network Bound Disk Encryption (NBDE) to securely decrypt LUKS encrypted volumes. You will install the Tang server on our NBDE1 server, and install the Clevis client on NBDE3.
+.*Lab Length*
+* Medium/Average (~15 mins)
 
-== Introduction
-Network-Bound Disk Encryption (NBDE) allows the user to encrypt root volumes of hard drives on physical and virtual machines without requiring to manually enter a password when systems are restarted.  Red Hat Enterprise Linux implements NBDE with a central server named Tang, and and client framework named Clevis.
+.*Goal*
+* Understand how to use Network Bound Disk Encryption (NBDE) to securely decrypt LUKS-encrypted volumes
 
-Tang is used to bind data to a secure network.  It is stateless and does not require TLS or authentication.  Tang does not interact with client keys, so it never obtains identifying information from the client.  Clevis provides automated unlocking of LUKS volumes.
+== 3.1: Introduction
+Network Bound Disk Encryption (NBDE) allows the user to encrypt root volumes of hard drives on physical and virtual machines without requiring manual entry of a password when systems are restarted.
 
-Clevis and Tang are generic client and server components that provide network bound encryption. In Red Hat Enterprise Linux 7, they are used in conjunction with LUKS to encrypt and decrypt root and non-root storage volumes to accomplish Network Bound Disk Encryption.
+Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL) implements NBDE with a central server named Tang and a client framework named Clevis. Tang is used to bind data to a secure network. It is stateless and does not require TLS or authentication. Tang does not interact with client keys, so it never obtains identifying information from the client. Clevis provides automated unlocking of LUKS volumes.
 
-This lab covers setting up NBDE using command line interface, but Cockpit also provides same functionality in cockpit-storaged. You are able to add, edit and remove both passphrase based keys and keyserver key.
+Tang and Clevis are generic server and client components that provide network bound encryption. In Red Hat Enterprise Linux 7, they are used in conjunction with LUKS to encrypt and decrypt root and non-root storage volumes to accomplish NBDE.
 
-== Lab 3.1 Installing the Tang server
-. Navigate to the Lab information page from *Lab 0 Setup steps*. This page has your environment's power control and consoles. Click on the console for *NBDE1*. Login to the NBDE1 server as *root* using the password *r3dh4t1!* (if you are prompted for the disk decryption password, it is *r3d4t1!*).
+This lab covers setting up NBDE using the command line interface, but Cockpit also provides the same functionality in `cockpit-storaged`. You are able to add, edit, and remove both passphrase-based keys and key server keys.
 
+You install the *Tang* server on the *NBDE1* server and the Clevis client on *NBDE3*.
+
+== 3.2: Installing the Tang Server
+. Navigate to the lab information page from *Lab 0: Setup Steps* and click *CONSOLE* for *NBDE1*:
 +
 image:images/lab3-console.png[200,200]
-
-. Then, install the tang packages
 +
-[source, text]
+This page has your environment's power control and consoles.
+
+. Log in to the *NBDE1* server as *root* using *r3dh4t1!* as the password. (If you are prompted for the disk decryption password, it is also *r3d4t1!*).
+
+. Install the `tang` packages:
++
+----
 [root@nbde1 ~]# yum install tang
+----
 +
+[TIP]
+====
+To copy and paste text to send to the console without typing into the console directly, press the *T* button at the top right of your console. This is recommended for longer commands.
 
-NOTE:
-If you wanted to copy and paste text to send to the console, you could also press the *T* button at the top right of your console if you didn't want to type text into the console directly. This is mainly recommended for longer commands.
 image:images/console-textbox.png[500,500]
+====
 
-. Finally, enable the tang service in systemd and open the HTTP port in firewall:
+. Enable the `tang` service in `systemd` and open the HTTP port in the firewall:
 +
-[source, text]
+----
 [root@nbde1 ~]# systemctl enable tangd.socket --now
 [root@nbde1 ~]# firewall-cmd --add-service=http
 [root@nbde1 ~]# firewall-cmd --add-service=http --permanent
+----
++
+Because `tangd` uses the `systemd` socket activation mechanism, the server starts as soon as it receives the first connection. A new set of cryptographic keys is automatically generated upon initial startup.
 
-Since tangd uses the systemd socket activation mechanism, the server starts as soon as the first connection comes in. A new set of cryptographic keys is automatically generated at the first start.
+== 3.3: Installing the Clevis Client
+Your *NBDE3* client is already encrypted. In this section, you install the client packages that allow you to decrypt the root device drive upon boot without manual intervention.
 
-== Lab 3.2 Installing the Clevis Client
-Your NBDE3 client is already encrypted and this exercise will install the client packages that will allow you to un-encrypt the root device drive upon boot without manual intervention.
+. Navigate to the lab information page from *Lab 0: Setup Steps*.
++
+This page has your environment's power control and consoles.
 
-. Navigate to the Lab information page from *Lab 0 Setup steps*. This page has your environment's power control and consoles. Click on the console for *NBDE3*. The passphrase for the LUKS encrypted disk on *NBDE3* is *r3dh4t1!*. You will need to enter the pass phrase to complete the boot process.  If you wanted to copy and paste text to send to the console, press the *T* button at the top right of your console.
+. Click the console link for *NBDE3*:
 +
 image:images/lab3-console2.png[200,200]
++
+. Enter the passphrase *r3dh4t1!* for the LUKS-encrypted disk on *NBDE3* to complete the boot process.
++
+[TIP]
+====
+To copy and paste text to send to the console, press the *T* button:
+
 image:images/console-textbox.png[500,500]
+====
 
-. Login to the NBDE3 server as *root* using the password *r3dh4t1!*.
-. Then, install the clevis packages:
+. Log in to the *NBDE3* server as *root* using *r3dh4t1!* as the password:
+
+. Install the Clevis packages:
 +
-[source, text]
+----
 [root@nbde3 ~]# yum install clevis clevis-luks clevis-dracut
-. Next, we will initialize the luks binding to the tang server. If you wanted to copy and paste the text below to send to the console, press the *T* button at the top right of your console (See the picture above on Step #1).
+----
+
+. Initialize the LUKS binding to the *Tang* server.
+
 +
-[source, text]
+----
 [root@nbde3 ~]# clevis luks bind -d /dev/vda2 tang '{"url":"http://nbde1.example.com"}'
+----
 +
-NOTE: This command performs four steps:
-1) Creates a new key with the same entropy as the LUKS master key.
-2) Encrypts the new key with Clevis.
-3) Stores the Clevis JWE object in the LUKS header with LUKSMeta.
-4) Enables the new key for use with LUKS.
+[TIP]
+====
+To copy and paste the to send to the console, press the *T* button:
 
-. You will be asked to trust the keys. Answer ‘y’ to this question.
-. Next, enter the existing LUKS password, which is *r3dh4t1!*.
-
-
-. This disk can now be unlocked with your existing passphrase as well as with the Clevis policy.
-
-== Lab 3.3 Verify LUKS Header
-. To verify that the Clevis JWE object is successfully placed in a LUKS header, use the `cryptsetup luksDump` command on *NBDE3*.
-You should see that there are two keyslots in the header. Keyslot 0 represents the static password you had to enter when booting the machine for the first time. Keyslot 1 is the newly added entry by the `clevis luks bind` command.
+image:images/console-textbox.png[500,500]
+====
 +
-[source, text]
-```
+This command performs four steps:
+
+* Creates a new key with the same entropy as the LUKS master key
+* Encrypts the new key with Clevis
+* Stores the Clevis JWE object in the LUKS header with LUKSMeta
+* Enables the new key for use with LUKS
+
+. Answer `y` when asked to trust the keys.
+
+. Enter *r3dh4t1!*, which is the existing LUKS password.
+
+This disk can now be unlocked with your existing passphrase, as well as with the Clevis policy.
+
+== 3.4: Verifying the LUKS Header
+
+. Use the `cryptsetup luksDump` command on *NBDE3* to verify that the Clevis JWE object is successfully placed in a LUKS header:
++
+----
 [root@nbde3 ~]# cryptsetup luksDump /dev/vda2
 LUKS header information
 Version:       	2
@@ -133,85 +169,120 @@ Digests:
 	Digest:     b7 42 05 a6 84 23 e2 26 af d7 2d db bf 21 27 29
 	            b7 23 26 c1 07 08 52 bc e2 a7 93 75 21 7f 80 b1
 ```
+----
 
-== Lab 3.4 Enable Decryption on the Boot Process
-. To enable the early boot system to process the disk binding, enter the following command on *NBDE3*.
+. Examine the header and expect to see that there are two key slots in the header.
 +
-[source, text]
+The `0` key slot represents the static password you entered when booting the machine for the first time and key slot `1` is the newly added entry by the `clevis luks bind` command.
+
+== 3.5: Enabling Decryption on the Boot Process
+
+. Enter the following command on *NBDE3* to enable the early boot system to process the disk binding:
++
+----
 [root@nbde3 ~]# dracut -f
-
+----
 +
-NOTE: Pass the *-vf* parameter if you want to see verbose output.
+[TIP]
+====
+Pass the *-vf* parameter if you want to see verbose output.
+====
 
-== Lab 3.5 Reboot *NBDE3* and test that NBDE was successfully configured
-. Reboot *NBDE3*.  When the prompt comes up for the LUKS passphrase, wait for a while (it might take up to *5 minutes* in the virtualized environment) and *NBDE3*  should automatically begin the boot process without requiring you to enter a password.
+== 3.6: Rebooting NBDE3 and Testing the NBDE Configuration
 
+. Reboot *NBDE3*:
 +
-[source, text]
+----
 [root@nbde3 ~]# reboot
+----
 
-== Lab 3.6 Initializing the luks binding to the tang server using Cockpit
+. Wait for the prompt to come up for the LUKS passphrase and expect *NBDE3* to automatically begin the boot process without requiring you to enter a password.
++
+This may take up to five minutes in the virtualized environment.
 
-Your NBDE2 server is already encrypted and this exercise will install the client packages that will allow you to un-encrypt the root device drive upon boot without manual intervention.
+== 3.7: Initializing the LUKS Binding to the Tang Server using Cockpit
 
-. Navigate to the Lab information page from *Lab 0 Setup steps*. This page has your environment's power control and consoles. Click on the console for *NBDE2*. The passphrase for the LUKs encrypted disk on *NBDE2* is *r3dh4t1!*. You will need to enter the pass phrase to complete the boot process.  If you wanted to copy and paste text to send to the console, press the *T* button at the top right of your console.
+=== 3.7.1: Accessing NBDE2 Console
+
+Your *NBDE2* server is already encrypted. In this section, you install the client packages that allow you to decrypt the root device drive upon boot without manual intervention.
+
+. Navigate to the lab information page from *Lab 0: Setup Steps*.
++
+This page has your environment's power control and consoles.
+
+. Click *CONSOLE* for *NBDE2* and use the passphrase *r3dh4t1!* for the LUKS-encrypted disk on *NBDE2*:
 +
 image:images/lab3-console2.png[200,200]
++
+You must enter the passphrase to complete the boot process. You do not need to log in to the machine after unlocking the disk with the passphrase.
++
+[TIP]
+====
+To copy and paste text to send to the console, press the *T* button:
+
 image:images/console-textbox.png[500,500]
+====
++
+The `cockpit-storaged` package is already installed for you, and Cockpit is already enabled as well.
 
-. You do not need to login to the machine after unlocking the disk with the passphrase. Cockpit-storaged package was preinstalled for you. Cockpit was enabled as well.
+=== 3.7.2: Initializing the LUKS Binding
 
-. Next, we will initialize the luks binding to the tang server using Cockpit.
+In this section, you initialize the LUKS binding to the *Tang* server using Cockpit.
 
-. Go to your *Lab Information* webpage from the *Lab 0 setup steps* and click on the console button for your workstation bastion host. Login as *lab-user* with *r3dh4t1!* as the password.
+. Go to your *Lab Information* webpage from *Lab 0: Setup Steps* and click *CONSOLE* for your workstation bastion host:
 +
 image:images/lab1.1-workstationconsole.png[300,300]
+
+. Log in as *lab-user* with *r3dh4t1!* as the password:
++
 image:images/lab1.1-labuserlogin.png[300,300]
 
 . Open a Firefox web browser:
 +
 image:images/nbde_cockpit_firefox.png[]
 
-. Open https://nbde2.example.com:9090/
+. Open link:https://nbde2.example.com:9090/[https://nbde2.example.com:9090/^]:
 +
 image:images/nbde_cockpit_firefox_1.png[]
 
-. Login as root user using *r3dh4t1!* as the password. Next, access *Storage* menu and then click on VirtiO Disk.
+. Log in as *root*, using *r3dh4t1!* for the password.
+
+. Click *Storage*, then click *VirtiO Disk*:
 +
 image:images/nbde_cockpit_storage_page.png[]
 
-. Next, click on *Encrypted data* for */dev/vda2*:
+. Click *Encrypted data* for */dev/vda2*:
 +
 image:images/nbde_cockpit_disk_page.png[]
 
-. Next, click on the *Ecnryption* tab for the disk:
+. Click the *Encryption* tab for the disk:
 +
 image:images/nbde_cockpit_disk_page_1.png[]
-
-. It will show current keys for disk. Currently, there is only one passphrase key:
++
+. Expect to see the current keys for the disk, and note that at present there is only one passphrase key:
 +
 image:images/nbde_cockpit_disk_enc.png[]
 
-. Click on *+* button to add one more key. You will see modal window looking like this:
+. Click the *+* button to add one more key, and expect the modal window to look like this:
 +
 image:images/nbde_cockpit_tang_empty.png[]
 
-. As a Keyserver address we will use *nbde1.example.com* and *r3dh4t1!* for existing disk passphrase. So, fill the modal window fields like this and click *Add* button:
+. Complete the modal window fields as shown, using *nbde1.example.com* as a key server address and *r3dh4t1!* for the existing disk passphrase, then click *Add*:
 +
 image:images/nbde_cockpit_tang_filled.png[]
 
-. It will take some take for it to process the request. After this click *Trust key*:
+. After giving the system some time to process the request, click *Trust key*:
 +
 image:images/nbde_cockpit_tang_confirm.png[]
-NOTE:
-Your key will differ from the key shown in the image below.
 
-. After this you will see both Disk passphrase and Keyserver as your keys for the disk:
-
+. Examine the results, and note both the disk passphrase and the key server as your keys for the disk:
++
 image:images/nbde_cockpit_keys_result.png[]
++
+Expect your key to be different from the key shown in the image.
 
 This disk can now be unlocked with your existing passphrase as well as with the Clevis policy.
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab4_IPsec.adoc[ Lab 4: IPSec ]
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab4_IPsec.adoc[Lab 4: IPsec^]

--- a/2020Labs/RHELSecurity/documentation/lab4_IPsec.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab4_IPsec.adoc
@@ -1,111 +1,119 @@
-= Lab 4: Cloud encryption using RHEL Opportunistic IPsec
+:toc2:
+:linkattrs:
 
-*Lab Length: Medium/Average (~15 mins)*
+== Lab 4: Cloud Encryption Using RHEL Opportunistic IPsec
 
-== Goal of Lab
-In this lab exercise, you will learn how to deploy Opportunistic
-IPsec to encrypt all host to host communication within an enterprise
-network. Whenever two hosts in the network want to send any kind of
-traffic, IPsec security will automatically activate and encrypt all
+.*Lab Length*
+* Medium/Average (~15 mins)
+
+.*Goal*
+* Learn how to deploy Opportunistic IPsec to encrypt all host-to-host communication
+within an enterprise network
+
+.*Objectives*
+* Generate X.509 certificates using a Python helper script
+* Configure Opportunistic IPsec on two or more nodes
+* Debug and monitor the network for IPsec encryption
+
+== 4.1: Introduction
+Whenever two hosts in the network send any kind of
+traffic, IPsec security automatically activates and encrypts all
 traffic between those hosts. This is also called mesh encryption.
 
-In this lab exercise, you will learn:
-
-* How to generate X.509 certificates using a python helper script
-* Configure Opportunistic IPsec on two or more nodes
-* How to debug and monitor the network for IPsec encryption
-
-== Introduction
-
 Imagine a LAN of various machines. Each machine is given an X.509
-certificate in the form of a PKCS#12 file (eg ipsecXXX.example.com). This
-file contains the Certificate Agency of Example Org and the node's own
-certificate and private key.  Machines in the network should automatically
+certificate in the form of a PKCS#12 file (for example, *ipsecXXX.example.com*).
+Machines in the network automatically
 initiate IPsec encryption and authenticate each other based on these
-certificates whenever any traffic is attempted between these nodes. We
-call this Opportunistic IPsec.
+certificates whenever any traffic is attempted between these nodes. This is
+called Opportunistic IPsec.
 
-There are two machines available to you for this specific lab
-exercise. But as this configuration method's main feature is scalability,
-you can pick up another X.509 certificate and repeat the process for any
-other provided lab VM. However, do be careful.  If you misconfigure IPsec
+There are two machines available to you for this lab.
+But because this configuration method's main feature is scalability,
+you can use another X.509 certificate and repeat the process for any
+other provided lab VM. But be careful--if you misconfigure IPsec
 and do not allow fallback to cleartext, you can lock yourself out of a VM.
 
-== Lab 4.1 Create and Install X.509 certificates
+== 4.2: Creating and Installing X.509 Certificates
 
-We will need to generate the required X.509 certificates. To make this
-easier, on ipsec.example.com, there is a script (/root/vpn-cert-gen.py)
-that generates x.509 certificates for ipsec.example.com and
-ipsec2.example.com for use with this exercise.  It also creates certificates
-for audit.example.com and usbguard.example.com if you want to try and add
-more machines to the encrypted mesh network. All our actions are run as root.
+In this section, you generate the required X.509 certificates. To make this
+easier, a script (`/root/vpn-cert-gen.py`) provided on *ipsec.example.com* generates x.509 certificates for *ipsec.example.com* and
+*ipsec2.example.com* for the lab. If you want to try to add
+more machines to the encrypted mesh network, it also creates certificates
+for *audit.example.com* and *usbguard.example.com*. All your actions are run as *root*.
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *ipsec.example.com* host as *root*.
+. Log in to the *ipsec.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@ipsec.example.com
 ----
-. In order to create the X.509 certificates for the lab, run the following
-commands:
 
-	[root@ipsec ~]# mkdir /root/labcerts
-
-	[root@ipsec ~]# cd /root/labcerts
-
-	[root@ipsec labcerts]# /root/vpn-cert-gen.py --wipe
-	creating CA cert
-	OK: CA system completely re-initialized
-
-	[root@ipsec labcerts]# ls
-	cacerts  certs  keys  mobileconfig  pkcs12  serial.txt
-
-	[root@ipsec labcerts]# ls pkcs12/
-	audit.example.com.p12  ipsec2.example.com.p12  ipsec.example.com.p12  servera.example.com.p12  usbguard.example.com.p12
-
+. Create the X.509 certificates for the lab:
 +
-NOTE:
+----
+[root@ipsec ~]# mkdir /root/labcerts
 
-* The cacerts/ directory contains the Certificate Agency (CA) certificate.
-* The certs/ directory contains the regular node certificates
-* The keys/ directory contains the private keys. But the script has already combined these for you into PKCS#12 based certificates in the pkcs12/ directory.
-* The mobileconfig/ directory has Apple device profiles that include the PKCS#12 certificate and all other configuration items that are needed for those devices, but these files are only useful when building a Remote Access VPN server. We will not use them for
+[root@ipsec ~]# cd /root/labcerts
+
+[root@ipsec labcerts]# /root/vpn-cert-gen.py --wipe
+creating CA cert
+OK: CA system completely re-initialized
+
+[root@ipsec labcerts]# ls
+cacerts  certs  keys  mobileconfig  pkcs12  serial.txt
+
+[root@ipsec labcerts]# ls pkcs12/
+audit.example.com.p12  ipsec2.example.com.p12  ipsec.example.com.p12  servera.example.com.p12  usbguard.example.com.p12
+----
++
+The `cacerts/` directory contains the CA certificate.
++
+The `certs/` directory contains the regular node certificates.
++
+The `keys/` directory contains the private keys, but the script has already combined these for you into PKCS#12-based certificates in the `pkcs12/` directory.
++
+The `mobileconfig/` directory has Apple device profiles that include the PKCS#12 certificate and all of the other configuration items that are needed for those devices. These files are only useful when building a Remote Access VPN server. You do not use them for
 this mesh host-to-host encryption using Opportunistic IPsec.
 
-* Just pick the proper pkcs12/*.p12 files for each of the hosts you want to add to the crypto mesh.
 
-* Note that due to one security issue, the certificates must have a SubjectAltName specifying the IP address they are using (to prevent one machine from impersonating another). Since we do not have full reverse DNS and DNSSEC in this lab, libreswan cannot link the IP address to the hostname securely.  This is why the python script hardcodes the IP address in the SubjectAltName of the X.509
-certificate.
+. Select the proper `pkcs12/*.p12` files for each of the hosts you want to add to the crypto mesh.
 
-== Lab 4.2 Configure Opportunistic IPsec
+[IMPORTANT]
+====
+Due to security issues, the certificates must have a `SubjectAltName` specifying the IP address they are using, to prevent one machine from impersonating another. Because `my_sudo_group` does not have full reverse DNS and DNSSEC in this lab, `libreswan` cannot link the IP address to the host name securely. This is why the Python script hard-codes the IP address in the `SubjectAltName` of the X.509 certificate.
+====
 
-. In order to setup ipsec.example.com, first install libreswan and initialize the
-certificate database using the following commands:
+== 4.3: Configuring Opportunistic IPsec
 
-	[root@ipsec ~]# yum install libreswan
-	[root@ipsec ~]# ipsec initnss
+=== 4.3.1: Installing and Initializing `libreswan` and Importing the Certificate
 
-. Once libreswan is installed, you can import the PKCS#12 certificate:
+. Install `libreswan` and initialize the certificate database using the following commands to first set up *ipsec.example.com*:
++
+----
+[root@ipsec ~]# yum install libreswan
+[root@ipsec ~]# ipsec initnss
+----
 
-	[root@ipsec ~]# ipsec import /root/labcerts/pkcs12/ipsec.example.com.p12
-	Enter password for PKCS12 file:
-	pk12util: PKCS12 IMPORT SUCCESSFUL
-	correcting trust bits for Certificate Agency (CA) - Test Org
+. After `libreswan` is installed, import the PKCS#12 certificate:
++
+----
+[root@ipsec ~]# ipsec import /root/labcerts/pkcs12/ipsec.example.com.p12
+Enter password for PKCS12 file:
+pk12util: PKCS12 IMPORT SUCCESSFUL
+correcting trust bits for Certificate Agency (CA) - Test Org
+----
 
 . When prompted for the import password, type *secret*.
 
-. You can confirm the node's certificate and CA certificate are installed and
-available to libreswan:
+. Confirm that the node's certificate and CA certificate are installed and
+available to `libreswan`:
 +
-[source]
-....
+----
 [root@ipsec ~]# certutil -L -d sql:/etc/ipsec.d
 
 Certificate Nickname                                         Trust Attributes
@@ -113,88 +121,106 @@ Certificate Nickname                                         Trust Attributes
 
 mycert                                                       u,u,u
 Certificate Agency (CA) - Test Org                           CT,,
-....
+----
 
-. Now our two hosts *ipsec.example.com* and *ipsec2.example.com* need to be configured
-for IPsec. For these two hosts, we have pre-created the configuration file for
-you and placed it on the machine at /root/oe-cert.conf . Copy this file into the
-/etc/ipsec.d/ directory so libreswan can use it:
+=== 4.3.2: Configuring Hosts for IPsec
 
-	[root@ipsec ~]# cp /root/oe-cert.conf /etc/ipsec.d/
+In this section, you configure the *ipsec.example.com* and *ipsec2.example.com* hosts
+for IPsec. For these two hosts, the configuration file is already created for
+you and placed on the machine at `/root/oe-cert.conf`.
 
+. Copy this file into the `/etc/ipsec.d/` directory so that `libreswan` can use it:
 +
-NOTE: If you look at the file /root/oe-cert.conf, you will see it defines a number of
-connections.  These connections are the different groups that we can assign
-to network IP ranges. The conn "private" means that IPsec is mandatory and all
-plaintext will be dropped. The conn "private-or-clear" means that IPsec is
-attempted, but it will fallback to cleartext if it fails. The conn
-"clear-or-private" means it will not initiate IPsec but it will respond to a
-request for IPsec. The conn "clear" will never allow or initiate IPsec.
+----
+[root@ipsec ~]# cp /root/oe-cert.conf /etc/ipsec.d/
+----
++
+[NOTE]
+====
+If you look at the `/root/oe-cert.conf` file, you can see it defines a number of
+connections. These connections are the groups that you can assign
+to network IP ranges. A connection specification is defined within a `conn`
+section in the configuration file.
 
-. If you are running with SElinux enabled, ensure all the files are properly
-labeled:
+* `conn private` means that IPsec is mandatory and all plaintext is to be dropped.
+* `conn private-or-clear` means that IPsec is attempted, but it falls back to cleartext if it fails.
+*  `conn clear-or-private` means that it does not initiate IPsec, but responds to a
+request for IPsec.
+* `conn clear` never allows or initiates IPsec.
+====
 
-	[root@ipsec ~]# restorecon -Rv /etc/ipsec.*
+. If you are running with SElinux enabled, make sure that all of the files are
+properly labeled:
++
+----
+[root@ipsec ~]# restorecon -Rv /etc/ipsec.*
+----
 
-. To add an IP address (eg 192.168.0.66) or network range (eg
-192.168.0.0/24) into one of these groups, simply add one line with the
+. Add an IP address (for example, `192.168.0.66`) or network range (for example,
+`192.168.0.0/24`) into one of these groups, by simply adding one line with the
 IP address or network (in CIDR notation) into one of the files matching
-the connection name in /etc/ipsec.d/policies. We will configure the machines
-to attempt Opportunistic IPsec for the entire 192.168.0.0/24 range by adding
-that network range to the "private-or-clear" group:
+the connection name in `/etc/ipsec.d/policies`.
 
-	[root@ipsec ~]# echo "192.168.0.0/24" >> /etc/ipsec.d/policies/private-or-clear
-
-. To ensure you will always be able to login to all machines via the workstation,
-we will add a more specific entry into the "clear" group so Workstation
-communication always happen unencrypted and we can always use it to login to
-other machines to reconfigure or debug:
-
-	[root@ipsec ~]# echo "192.168.0.3/32" >> /etc/ipsec.d/policies/clear
-
-. And finally, we need to tell the firewalld system service that we want to open the firewall
-for the required packets for IPsec:
-
-	[root@ipsec ~]# firewall-cmd --add-service=ipsec --permanent
-
-	[root@ipsec ~]# firewall-cmd --reload
-
-== Lab 4.3 Transfer the Configuration to a Second System
-
-. Now we will configure the next machine, ipsec2.example.com. Since the
-ipsec.example.com host contains all the certificates, we need to copy the
-certificate onto ipsec2.example.com via the workstation VM:
-
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. Configure the machines to attempt Opportunistic IPsec for the entire
+`192.168.0.0/24` range by adding that network range to the `private-or-clear`
+group:
 +
-[source]
+----
+[root@ipsec ~]# echo "192.168.0.0/24" >> /etc/ipsec.d/policies/private-or-clear
+----
+
+. Add a more specific entry into the "clear" group so that workstation
+communication always takes place unencrypted and you can always use it to log in to
+other machines to reconfigure or debug:
++
+----
+[root@ipsec ~]# echo "192.168.0.3/32" >> /etc/ipsec.d/policies/clear
+----
++
+This allows you to log in to all of the machines via the workstation.
+
+. Tell the `firewalld` system service that you want to open the firewall
+for the required packets for IPsec:
++
+----
+[root@ipsec ~]# firewall-cmd --add-service=ipsec --permanent
+
+[root@ipsec ~]# firewall-cmd --reload
+----
+
+== 4.4: Transferring the Configuration to a Second System
+
+In this section, you configure the next machine, *ipsec2.example.com*. Because the
+*ipsec.example.com* host contains all of the certificates, you must copy the
+certificate onto *ipsec2.example.com* via the workstation VM:
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
++
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+
+[lab-user@workstation-GUID ~]$ scp root@ipsec.example.com:/root/labcerts/pkcs12/ipsec2.example.com.p12 .
+
+[lab-user@workstation-GUID ~]$ scp root@ipsec.example.com:/root/oe-cert.conf .
+
+[lab-user@workstation-GUID ~]$ scp ipsec2.example.com.p12 oe-cert.conf root@ipsec2.example.com:/root/
 ----
 
-	[lab-user@workstation-GUID ~]$ scp root@ipsec.example.com:/root/labcerts/pkcs12/ipsec2.example.com.p12 .
+. Install `libreswan`, import the certificate on *ipsec2.example.com*, and configure it for Opportunistic IPsec:
 
-	[lab-user@workstation-GUID ~]$ scp root@ipsec.example.com:/root/oe-cert.conf .
-
-	[lab-user@workstation-GUID ~]$ scp ipsec2.example.com.p12 oe-cert.conf root@ipsec2.example.com:/root/
-
-. Then we install libreswan, import the certificate on ipsec2.example.com, and configure it for Opportunistc IPsec:
-
-. Log into the *ipsec2.example.com* host as *root*.
+. Log in to the *ipsec2.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@ipsec2.example.com
 ----
 +
-[source]
 ----
 [root@ipsec2 ~]# yum install libreswan
 
 [root@ipsec2 ~]# ipsec initnss
 
 [root@ipsec2 ~]# ipsec import /root/ipsec2.example.com.p12
-(Note: The password for PKCS12 file is secret)
+(Note: The password for PKCS12 file is "secret".)
 
 [root@ipsec2 ~]# rm /root/ipsec2.example.com.p12
 
@@ -210,153 +236,189 @@ certificate onto ipsec2.example.com via the workstation VM:
 
 [root@ipsec2 ~]# firewall-cmd --reload
 ----
-
++
 Now you have configured the first two nodes. For each additional node, all you
 need to do is generate and install a new certificate, add the same configuration
-file with updated leftcert= entry and update the policy groups in
-/etc/ipsec.d/policies/ to match the first two nodes of the cluster. So for each
+file with the updated `leftcert=` entry, and update the policy groups in
+`/etc/ipsec.d/policies/` to match the first two nodes of the cluster. So for each
 added node, you do not need to reconfigure any of the previous nodes, as those
 are already configured to trust the same CA and talk IPsec to the same IP ranges
-as the new nodes. In a production setting, you should be able to populate new nodes
-using ansible as all configuration files (other then the PKCS#12 certificate) are
-identical on all the nodes.
+as the new nodes. Because all of the configuration files (other then the PKCS#12 certificate) are
+identical on all or the nodes, in a production setting, you should be able to populate new nodes
+using Ansible^(R)^.
 
-== Lab 4.4 Using Opportunistic IPsec
+== 4.5: Using Opportunistic IPsec
 
-. Now we are ready for testing our configuration. Start the IPsec subsystem on BOTH *ipsec* and *ipsec2*:
+You are now ready to test the configuration.
 
-	[root@ipsec ~]# systemctl start ipsec
+First, you start the IPsec subsystem on both of the hosts.
 
-. And on the other host:
+. Start the IPsec subsystem on *ipsec.example.com*:
++
+----
+[root@ipsec ~]# systemctl start ipsec
+----
 
-	[root@ipsec2 ~]# systemctl start ipsec
+. Start the IPsec subsystem on *ipsec2.example.com*:
++
+----
+[root@ipsec2 ~]# systemctl start ipsec
+----
++
+. Wait a few seconds for the two hosts to load their IPsec policies.
 
-. Once you have done this on both machines, wait for a few seconds for both machines to
-load their IPsec policues. Then a simple ping from ipsec.example.com
-to ipsec2.example.com (or visa versa) should trigger an IPsec tunnel. The first
-ping might or might not fail depending on the time it takes to setup the IPsec
+. On *ipsec.example.com*, `ping` *ipsec2.example.com* from *ipsec.example.com* to trigger an IPsec tunnel:
++
+----
+[root@ipsec ~]# ping -c3 ipsec2.example.com
+----
++
+The first `ping` may fail depending on the time it takes to set up the IPsec
 connection.
 
-. On *ipsec.example.com* type:
-
-	[root@ipsec ~]# ping -c3 ipsec2.example.com
-
-. You can check the system logs in /var/log/secure, or you can use one of the
+. Examine the system logs in `/var/log/secure`, or you can use one of the
 various status commands available:
++
+----
+[root@ipsec ~]# ipsec trafficstatus
+006 #2: "private-or-clear#192.168.0.0/24"[1] ...192.168.0.22, type=ESP, add_time=1523268130, inBytes=1848, outBytes=1848, id='C=CA, ST=Ontario, L=Toronto, O=Test Org, OU=Clients, CN=ipsec.example.com, E=pwouters@redhat.com'
+----
 
-	[root@ipsec ~]# ipsec trafficstatus
-	006 #2: "private-or-clear#192.168.0.0/24"[1] ...192.168.0.22, type=ESP, add_time=1523268130, inBytes=1848, outBytes=1848, id='C=CA, ST=Ontario, L=Toronto, O=Test Org, OU=Clients, CN=ipsec.example.com, E=pwouters@redhat.com'
+. Examine the output to see the non-zero byte counters for IPsec packets that shows that the kernel
+IPsec subsystem has encrypted and decrypted network packets.
++
+[TIP]
+====
+A more verbose command is:
 
-. You can see the non-zero byte counters for IPsec packets that shows the kernel
-IPsec subsystem has encrypted and decrypted the network packets. A more verbose
-command is:
+----
+[root@ipsec ~]# ipsec status
+<lots of output>
+----
+====
 
-	[root@ipsec ~]# ipsec status
-	<lots of output>
+Your two nodes now have an IPsec-encrypted mesh network running.
 
-That's it! You have your two node IPsec encrypted mesh network running.
+== 4.6: Troubleshooting (Optional)
 
-== Lab 4.5 Troubleshooting (Optional)
+. If you think something went wrong and the `ipsec status` command does not show you
+the `private`, `private-or-clear`, and `clear-or-private` connections (and their
+instances), issue a manual command to see why loading failed:
++
+----
+[root@ipsec ~]# ipsec auto --add private
+----
 
-. If you think something went wrong and the ipsec status command does not show you
-the connections private, private-or-clear and clear-or-private (and their
-instances) then issue a manual command to see why loading failed:
-
-	[root@ipsec ~]# ipsec auto --add private
-
-. If there is some kind of failure (eg the group is "private" but the remote end
-is not functional), there will be no IPsec tunnel visible, but you should be
-able to see the "shunts" that prevent or allow unencrypted traffic on the
-network.
-
-	[root@ipsec ~]# ipsec whack --shuntstatus
-	000 Bare Shunt list:
-	000
-	000 192.168.0.23/32:0 -0-> 192.168.0.22/32:0 => %drop 0    oe-failing
-
-. There are a few different types of shunt. The negotiationshunt determines what
+. If there is some kind of failure (such as the group is `private` but the remote end
+is not functioning), do not expect to see a visible IPsec tunnel, but
+examine the results and expect to see the _shunts_ that prevent or allow unencrypted
+traffic on the network:
++
+----
+[root@ipsec ~]# ipsec whack --shuntstatus
+000 Bare Shunt list:
+000
+000 192.168.0.23/32:0 -0-> 192.168.0.22/32:0 => %drop 0    oe-failing
+----
++
+[NOTE]
+====
+There are a few kinds of shunts. The `negotiationshunt` determines what
 to do with packets while the IPsec connection is being established. Usually
-people want to hold the packets to prevents leaks, but if encryption is only
+people want to hold the packets to prevent leaks, but if encryption is only
 "nice to have" and an uninterrupted service is more important, you can set this
-option to "passthrough". The failureshunt option determines what to do when
-negotiation fails. For the "private-or-clear" entry in your configuration file,
-you can see it is set to "passthrough", allowing unencrypted traffic. For the
-"private" entry you can see it is set to "drop" to disallow unencrypted traffic.
+option to `passthrough`. The `failureshunt` option determines what to do when
+negotiation fails. For the `private-or-clear` entry in your configuration file,
+you can see it is set to `passthrough`, allowing unencrypted traffic. For the
+`private` entry you can see it is set to `drop` to disallow unencrypted traffic.
+====
 
-. You can use tcpdump to confirm that the connection is encrypted. Run a ping on
-one host, and run tcpdump on the other host:
-
-	[root@ipsec ~]# tcpdump -i ens3 -n esp
-	tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
-	listening on ens3, link-type EN10MB (Ethernet), capture size 262144 bytes
-	05:58:18.003410 IP 192.168.0.22 > 192.168.0.23: ESP(spi=0x84019944,seq=0x6), length 120
-	05:58:18.003684 IP 192.168.0.23 > 192.168.0.22: ESP(spi=0x5b312cc5,seq=0x6), length 120
-	05:58:19.004840 IP 192.168.0.22 > 192.168.0.23: ESP(spi=0x84019944,seq=0x7), length 120
-	05:58:19.005096 IP 192.168.0.23 > 192.168.0.22: ESP(spi=0x5b312cc5,seq=0x7), length 120
-	05:58:20.006529 IP 192.168.0.22 > 192.168.0.23: ESP(spi=0x84019944,seq=0x8), length 120
-	05:58:20.006730 IP 192.168.0.23 > 192.168.0.22: ESP(spi=0x5b312cc5,seq=0x8), length 120
-
-. If you see ESP packets with tcpdump, it means the connection is sending
-encrypted traffic. If you use ping and see ICMP packets, then the connection is
-not encrypted. Due due to how the kernel hooks for IPsec and tcpdump interacts,
+. Run `ping` on one host and `tcpdump` on the other host to confirm that the
+connection is encrypted:
++
+----
+[root@ipsec ~]# tcpdump -i ens3 -n esp
+tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+listening on ens3, link-type EN10MB (Ethernet), capture size 262144 bytes
+05:58:18.003410 IP 192.168.0.22 > 192.168.0.23: ESP(spi=0x84019944,seq=0x6), length 120
+05:58:18.003684 IP 192.168.0.23 > 192.168.0.22: ESP(spi=0x5b312cc5,seq=0x6), length 120
+05:58:19.004840 IP 192.168.0.22 > 192.168.0.23: ESP(spi=0x84019944,seq=0x7), length 120
+05:58:19.005096 IP 192.168.0.23 > 192.168.0.22: ESP(spi=0x5b312cc5,seq=0x7), length 120
+05:58:20.006529 IP 192.168.0.22 > 192.168.0.23: ESP(spi=0x84019944,seq=0x8), length 120
+05:58:20.006730 IP 192.168.0.23 > 192.168.0.22: ESP(spi=0x5b312cc5,seq=0x8), length 120
+----
++
+If you see ESP packets with `tcpdump`, it means the connection is sending
+encrypted traffic. If you use `ping` and see ICMP packets, then the connection is
+not encrypted. Due to how the kernel hooks for IPsec and `tcpdump` interact,
 if you look at all traffic over an interface, you might see unencrypted packets
 going out and encrypted (proto ESP) and decrypted packets coming in. This
-happens because packets are encrypted by IPsec after the tcpdump hook has seen
-the packet on some kernel version. The easiest indicator of whether traffic is
-encrypted is to use the above mentioned trafficstatus command.
+happens because packets are encrypted by IPsec after the `tcpdump` hook has seen
+the packet on some kernel versions. The easiest indicator of whether traffic is
+encrypted is to use the above-mentioned `trafficstatus` command.
 
-. Simply repeat this process on any new node to create your crypto mesh. If you
-have added the entire network range (192.168.0.0/24) to the private or
-private-or-clear groups, then for every new node you add, you do not need to
+. Simply repeat this process on any new node to create your crypto mesh.
++
+If you added the entire network range (`192.168.0.0/24`) to the `private` or
+`private-or-clear` groups, then for every new node you add, you do not need to
 reconfigure anything on the existing node.
 
-. You can also redo the test and not run libreswan on one node and do a ping. You
-should see a few packets stalled or failing (based on whether the IP or subnet
-appears in /etc/ipsec.d/policies/private or
-/etc/ipsec.d/policies/private-or-clear) before it fails to clear or installs a
+. Optionally, redo the test--but this time, do not run `libreswan` on one node--then perform a ping.
++
+Expect to see a few packets stalled or failing (based on whether the IP or subnet
+appears in `/etc/ipsec.d/policies/private` or
+`/etc/ipsec.d/policies/private-or-clear`) before it fails to clear or installs a
 block.
 
-. If you run into more problems or you want to see in great detail what is
-happening, you can enable two lines in /etc/ipsec.conf to get all logs in a file
-and with full debugging. It is important to use file logging with full debugging
-because otherwise the rsyslog or systemd ratelimit will kick in and you will
-miss messages.
+. Additionally, if you run into more problems or you want to see in detail what is
+happening, enable two lines in `/etc/ipsec.conf` to get all of the logs in a file
+with full debugging:
 +
-[source]
 ----
- # example /etc/ipsec.conf
- config setup
-	logfile=/var/log/pluto.log
-	plutodebug=all
+# example /etc/ipsec.conf
+config setup
+ logfile=/var/log/pluto.log
+ plutodebug=all
 
- include /etc/ipsec.d/*.conf
+include /etc/ipsec.d/*.conf
+----
++
+It is important to use file logging with full debugging
+because otherwise the `rsyslog` or `systemd ratelimit` may cause you to miss messages.
+
+. If everything works as expected, enable the IPsec
+services on your cluster on every startup--on each node run:
++
+----
+[root@ipsec ~]# systemctl enable ipsec
 ----
 
-. If everything works as expected, you would now be ready to enable the IPsec
-services on your cluster on every startup. So on each node run:
+For more information on Opportunistic IPsec, see link:https://libreswan.org/wiki/Main_Page[Opportunistic IPsec^].
 
-	[root@ipsec ~]# systemctl enable ipsec
+== 4.7: Resetting the IPsec NSS Certificate Database (Optional)
 
-For more information on Opportunistc IPsec, please see
-https://libreswan.org/wiki/Main_Page
+Libreswan uses the NDD cryptographic library. It keeps all of its X.509
+certificates and keys in its own NSS database in `/etc/ipsec.d`.
 
-== Resetting the IPsec NSS Certificate Database (Optional)
+. If you want restart the entire lab from scratch, run the
+following commands to remove the entire `libreswan` NSS database:
++
+[WARNING]
+====
+Executing these commands requires you to restart the IPsec lab from
+the beginning.
+====
++
+----
+[root@ipsec ~]# systemctl stop ipsec
+[root@ipsec ~]# rm /etc/ipsec.d/*.db
+[root@ipsec ~]# ipsec initnss
+Initializing NSS database
+----
 
-Libreswan uses the NDD cryptographic library. It keeps all its X.509
-certificates and keys in its own NSS database in /etc/ipsec.d. If for some
-reason you want restart the entire lab from scratch, then you want to remove the
-entire libreswan NSS database, run the following commands:
-
-CAUTION: running these commands will require you to restart the IPsec lab from
-the beginning
-
-	[root@ipsec ~]# systemctl stop ipsec
-	[root@ipsec ~]# rm /etc/ipsec.d/*.db
-	[root@ipsec ~]# ipsec initnss
-	Initializing NSS database
-
-Follow the same procedure for ipsec2.
+. Follow the same procedure for *ipsec2.example.com*.
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab5_USBGuard.adoc[ Lab 5: USBGuard ]
+link:README.adoc#table-of-contents[ Table of Contents^] | link:lab5_USBGuard.adoc[ Lab 5: USBGuard^]
+

--- a/2020Labs/RHELSecurity/documentation/lab5_USBGuard.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab5_USBGuard.adoc
@@ -1,153 +1,181 @@
-= Lab 5: USBGuard
+:toc2:
+:linkattrs:
 
-*Lab Length: Medium/Average (~15 mins)*
+== Lab 5: USBGuard
 
-== Goal of Lab
-The goal of this lab exercise is to introduce you to the basics of USBGuard.
+.*Lab Length*
+* Medium/Average (~15 mins)
 
-== Introduction
-USBGuard is a software framework that protects your systems against rogue USB devices by implementing basic whitelisting and blacklisting capabilities based on device attributes. This allows you to define access control to USB devices. For example, you can define what kind of USB devices are authorized and how a USB device may interact with your system.  It enables you to lock down all USB devices from user space.
+.*Goal*
+* Become familiar with the basics of USBGuard
 
-There are three main use cases for USBGuard: USB device whitelisting, USB device blacklisting, and triggering actions on USB device events. USBGuard can permit only known devices to create interfaces to it via USB (aka USB device whitelisting). Conversely, if a user doesn’t want to use a particular class of interfaces, he/she can block devices that want to communicate with the computer as an interface from that class (aka USB device blacklisting).   The final use case for USBGuard would be triggering actions on USB device events, such as when a particular USB device or USB device class is inserted, removed, etc. This feature might be used for auditing USB usage, screen locking ,etc.
+== 5.1: Introduction
+
+USBGuard is a software framework that protects your systems against rogue USB devices by implementing basic whitelisting and blacklisting capabilities based on device attributes. This allows you to define access control for USB devices. For example, you can define what kind of USB devices are authorized and how a USB device may interact with your system. It enables you to lock down all USB devices from user space.
+
+There are three main use cases for USBGuard: USB device whitelisting, USB device blacklisting, and triggering actions on USB device events. USBGuard can permit only known devices to create interfaces to it via USB (also known as USB device whitelisting). Conversely, if a user does not want to use a particular class of interfaces, the user can block devices that want to communicate with the computer as an interface from that class (also known as USB device blacklisting). The final use case for USBGuard is triggering actions on USB device events, such as when a particular USB device or USB device class is inserted or removed. This feature is often used for auditing USB usage or screen locking.
 
 [[Configuration]]
-== Pre-Configured Set Up Steps (Already done for you)
+== 5.2: Reviewing Preconfigured Setup Steps
 
-*Important*: All steps in this section have already been performed in this environment for you. This section is for informative purposes only. You can read these steps to get familiar with this lab exercise setup.
+[IMPORTANT]
+All of the steps in this setup section are already completed for you.
+This section is for reference only so that you know what is already configured in this lab environment.
 
-If you want to read these pre-configured set up steps later and just start with the lab exercise steps, go here: <<Lab 5.1 exercise steps>>.
+If you want to read these set up steps later, go directly to the <<Preliminary Knowledge and Concepts for the Lab>>.
 
-This lab exercise is based on a RHEL 8.0 VM residing inside this lab environment. KVM/libvirt is used to create and manage the virtual machine inside the RHEL 8.0 VM.
+This lab is based on a Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL) 8.0 VM residing inside this lab environment. KVM/libvirt is used to create and manage the virtual machine inside the RHEL 8.0 VM.
 
-=== Virtual machine naming information
+=== 5.2.1: Reviewing Virtual Machine Naming Information
 
-Please note that the instructions in this document refer to one of two VMs (apart from the workstation bastion host VM which is used as the common starting point).
+Note that the instructions in this document refer to one of two VMs (apart from the workstation bastion host VM that is used as the common starting point):
 
-1. *host*: This name refers to the *USBGuard* VM in this lab environment. The hostname of this VM is *usbguard.example.com*.
-2. *usbguard-demo*: This name refers to a virtual machine running on the *host* VM. The VM is managed from inside the *host* VM. No custom hostname is assigned to this machine. After logging in via `virsh console` you'll see *localhost* as the hostname.
+* The name *host* refers to the *USBGuard* VM in this lab environment. The host name of this VM is *usbguard.example.com*.
 
-During the lab exercise, you'll be asked to run commands on one or the other VM. This requires two parallel shell sessions. One connected to the *host* VM and the other connected to the *usbguard-demo* VM. How to connect from the *host* to *usbguard-demo* is explained in the <<Lab 5.1 exercise steps>> section.
+* The name *usbguard-demo* refers to a VM running on the *host* VM. The VM is managed from inside the *host* VM. No custom host name is assigned to this machine. After logging in via `virsh console`, expect to see *localhost* as the host name.
 
-=== Creating the virtual machine
+During the lab, you are asked to run commands on one VM or the other. This requires two parallel shell sessions--one connected to the *host* VM and the other connected to the *usbguard-demo* VM. How to connect from the *host* to *usbguard-demo* is explained in the <<Logging in to the *usbguard-demo* VM>> section.
 
-First, configure virt-builder to use our internal RHEL images:
+=== 5.2.2: Creating the Virtual Machine
 
-	# cat -> /etc/virt-builder/repos.d/rhel.conf <<EOF
-	[rhel]
-	uri=http://file.rdu.redhat.com/~rjones/builder/index.asc
-	EOF
+. Configure `virt-builder` to use the internal RHEL images:
++
+----
+# cat -> /etc/virt-builder/repos.d/rhel.conf <<EOF
+[rhel]
+uri=http://file.rdu.redhat.com/~rjones/builder/index.asc
+EOF
+----
 
-Then, create the usbguard VM image using virt-builder (from libguestfs-tools-c package):
+. Create the `usbguard` VM image using `virt-builder` (from the `libguestfs-tools-c` package):
++
+----
+> virt-builder rhel-8.0 -o usbguard-rhel-8.0-vm.qcow2 --format qcow2 --root-password password:redhat --update --install usbguard --install usbguard-tools --install usbutils --install udisks2
+----
 
-	> virt-builder rhel-8.0 -o usbguard-rhel-8.0-vm.qcow2 --format qcow2 --root-password password:redhat --update --install usbguard --install usbguard-tools --install usbutils --install udisks2
+=== 5.2.3: Setting Up the Virtual Machine
 
-=== Setting up the virtual machine
+. Transfer the `usbguard` VM image to the host VM.
 
-First transfer the usbguard VM image to the host VM.
-
-Then ssh into the host VM and install the usbguard VM using virt-install (from virt-install package):
-
-	[root@usbguard]# virt-install --name usbguard-demo --memory 512 --disk /var/lib/libvirt/images/usbguard-rhel-8.0-vm.qcow2 --graphics none --os-variant rhel8.0 --import
+. SSH into the host VM and install the *usbguard* VM using `virt-install` (from the `virt-install` package):
++
+----
+[root@usbguard]# virt-install --name usbguard-demo --memory 512 --disk /var/lib/libvirt/images/usbguard-rhel-8.0-vm.qcow2 --graphics none --os-variant rhel8.0 --import
 
 Stop the VM if it is running using virsh:
 
-	[root@usbguard]# virsh list
-	 Id    Name                           State
-	----------------------------------------------------
-	 1     usbguard-demo                  running
+[root@usbguard]# virsh list
+	Id    Name                           State
+----------------------------------------------------
+	1     usbguard-demo                  running
 
 
-	[root@usbguard]# virsh destroy 1
+	root@usbguard]# virsh destroy 1
+----
 
-== **PLEASE READ CAREFULLY:** Preliminary knowledge and concepts for Lab exercise
+== 5.3: Reviewing Preliminary Knowledge and Concepts for the Lab
 
-This section shortly describes some of the workflows, files and tools used in the <<Lab 5.1 exercise steps>> section.
-The minimum you have to read in this section is the <<Simulating hot plugging with virsh>> topic.
-Make sure you create both `usb-disk.xml` and `usb-disk-2.xml` (see below) files if they don't already exist in your environment.
-If you are familiar with tools like `lsblk`, `udisksctl` and `virsh`, then you can skip this section and go straight to the <<Lab 5.1 exercise steps>>.
+[IMPORTANT]
+====
+Read this section carefully.
+====
 
-=== Simulating hot plugging with virsh
+This section describes some of the workflows, files, and tools used in the lab.
+Make sure you read the <<Simulating Hot Plugging with Virsh>> topic
+and create both the `usb-disk.xml` and `usb-disk-2.xml` files (see the next section) if they do not already exist in your environment.
+Then, if you are familiar with tools such as `lsblk`, `udisksctl` and `virsh`, you can skip the remainder of this section and go straight to the <<Logging in to the *usbguard-demo* VM>> section.
 
-Instead of configuring hot plug pass-through, it is easier to attach and detach USB drives to the virtual machine via `virsh`.
-XML file for virtual USB disk (usb-disk.xml):
+=== 5.3.1: Simulating Hot Plugging with Virsh
 
-	[root@usbguard]# cat usb-disk.xml
-	<disk type='file' device='disk'>
-   	 <driver name='qemu' type='raw' cache='none'/>
-   	 <source file='/tmp/usb-disk.img'/>
-   	 <target dev='vdd' bus='usb'/>
-   	 <serial>RED</serial>
-	</disk>
+Instead of configuring a hot plug passthrough, it is easier to attach and detach USB drives to the VM via `virsh`.
 
-Create as many XML files as you want to have available drives with unique serial values. Note that you have to create the file referenced in the `<source>` file attribute:
-
-	[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk.img bs=1M count=32
-
-The same steps are needed to create another USB disk used in this lab (usb-disk-2.xml).
-
-	[root@usbguard]# cat usb-disk-2.xml
-	<disk type='file' device='disk'>
-   	 <driver name='qemu' type='raw' cache='none'/>
-   	 <source file='/tmp/usb-disk-2.img'/>
-   	 <target dev='vde' bus='usb'/>
-   	 <serial>BLUE</serial>
-	</disk>
-
-	[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk-2.img bs=1M count=32
-
-From the host VM you can simulate USB disk hotplug using `virsh`:
-
-	[root@usbguard]# virsh attach-device usbguard-demo usb-disk.xml
-	[root@usbguard]# virsh detach-device usbguard-demo usb-disk.xml
-
-=== usbguard-demo VM description
-
-The usbguard-demo VM contains pre-installed (by virt-builder) _usbguard_, _usbguard-tools_, _usbutils_ and _udisks2_ packages. The VM is running RHEL 8.0.
-
-You can also use `udisksctl` to show the available status of a USB drive in the examples instead of `lsblk`.  Where you see `lsblk` in the guide, you can replace it with `udisksctl status`
-
-Output comparison with allowed drive attached as `sda`:
-
-	[root@localhost]# lsblk
-	NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
-	sda      8:0    1  7.6G  0 disk
-	└─sda1   8:1    1  7.6G  0 part
-	vda    253:0    0    6G  0 disk
-	├─vda1 253:1    0    1G  0 part /boot
-	├─vda2 253:2    0  615M  0 part [SWAP]
-	└─vda3 253:3    0  4.4G  0 part /
-
-	[root@localhost]# udisksctl status
-	MODEL                     REVISION  SERIAL                        DEVICE
-	--------------------------------------------------------------------------
-	VirtIO Disk                                                          vda
-	SMI USB DISK              1100      SMI_USB_DISK-0:0        sda
-
-== Lab 5.1 exercise steps
-
-=== Lab 5.1.1 Logging into the *usbguard-demo* VM
-Most steps are taken on the *usbguard-demo* virtual machine residing inside the *host* , *usbguard.example.com* virtual machine.  Adding and removing USB drives are done from the RHEL 8.0 *host* VM - *usbguard.example.com* .
-
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+. Create a file called `usb-disk.xml` to be used to create the virtual USB disk with the following contents:
 +
-[source]
+----
+[root@usbguard]# cat usb-disk.xml
+<disk type='file' device='disk'>
+   <driver name='qemu' type='raw' cache='none'/>
+   <source file='/tmp/usb-disk.img'/>
+   <target dev='vdd' bus='usb'/>
+   <serial>RED</serial>
+</disk>
+----
+
+. Create a USB disk using the `usb-disk.xml` file that you created:
++
+----
+[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk.img bs=1M count=32
+----
++
+Note that you must create the file referenced in the `<source>` file attribute.
++
+Create as many XML files as you want to have available drives with unique serial values.
+
+. Use the same steps to create another USB disk for use in this lab (`usb-disk-2.xml`):
++
+----
+[root@usbguard]# cat usb-disk-2.xml
+<disk type='file' device='disk'>
+   <driver name='qemu' type='raw' cache='none'/>
+   <source file='/tmp/usb-disk-2.img'/>
+   <target dev='vde' bus='usb'/>
+   <serial>BLUE</serial>
+</disk>
+
+[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk-2.img bs=1M count=32
+----
+
+. From the host VM, use `virsh` to simulate the USB disk hot plug:
++
+----
+[root@usbguard]# virsh attach-device usbguard-demo usb-disk.xml
+[root@usbguard]# virsh detach-device usbguard-demo usb-disk.xml
+----
+
+=== 5.3.2: Viewing *usbguard-demo* VM
+
+The *usbguard-demo* VM, running RHEL 8.0, contains the `usbguard`, `usbguard-tools`, `usbutils`, and `udisks2` packages, which were preinstalled by `virt-builder`.
+
+You can also use `udisksctl` to show the available status of a USB drive in the examples instead of `lsblk`. Where you see `lsblk` in the guide, you can replace it with `udisksctl status`.
+
+. Compare the output of these two commands with the allowed drive attached as `sda`:
++
+----
+[root@localhost]# lsblk
+NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+sda      8:0    1  7.6G  0 disk
+└─sda1   8:1    1  7.6G  0 part
+vda    253:0    0    6G  0 disk
+├─vda1 253:1    0    1G  0 part /boot
+├─vda2 253:2    0  615M  0 part [SWAP]
+└─vda3 253:3    0  4.4G  0 part /
+
+[root@localhost]# udisksctl status
+MODEL                     REVISION  SERIAL                        DEVICE
+--------------------------------------------------------------------------
+VirtIO Disk                                                          vda
+SMI USB DISK              1100      SMI_USB_DISK-0:0        sda
+----
+
+== 5.4: Logging in to the *usbguard-demo* VM
+Most of the steps in this section are performed on the *usbguard-demo* VM residing inside the *host*, *usbguard.example.com* VM. Adding and removing USB drives are done from the RHEL 8.0 *host* VM (*usbguard.example.com*).
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
++
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *usbguard.example.com* host as *root*.
+. Log in to the *usbguard.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@usbguard.example.com
 [root@usbguard ~]# export PS1="[\u@\[\e[44m\]\h\[\e[m\] \W]\\$ "
 ----
 
-. Now, let's start the *usbguard-demo* VM (which again resides INSIDE the *host* , *usbguard.example.com* virtual machine) and connect to its console. See steps below.
-
-IMPORTANT: You may see a blank console when connecting to the the *usbguard-demo* VM if it is slow to start
-
-....
+. Start the *usbguard-demo* VM (which resides _inside_ the *usbguard.example.com* VM host) and connect to its console:
++
+----
 [root@usbguard]# hostname
 usbguard
 [root@usbguard]# virsh start usbguard-demo
@@ -160,139 +188,174 @@ Red Hat Enterprise Linux Beta 8.0 (Ootpa)
 Kernel 4.18.0-74.el8.x86_64 on an x86_64
 
 localhost login:
-....
+----
++
+[IMPORTANT]
+====
+You may see a blank console when connecting to the *usbguard-demo* VM if it is slow to start.
+====
 
-Login as root using the password *redhat*.
+. Log in as *root* using *redhat* as the password.
 
-=== Lab 5.1.2 USBGuard dynamic policy
+== 5.5: Generating USBGuard Dynamic Policy
 
-Now let's generate a base policy without any external devices attached. This will allow the USB hubs and any other system level USB devices. The default action of USBGuard is to block any device not in the policy.
+In this section, you generate a base policy without any external devices attached. This allows USB hubs and any other system-level USB devices. The default action of USBGuard is to block any device not in the policy.
 
-. On usbguard-demo:
-	[root@localhost ~]# export PS1="[\u@\[\e[41m\]\h\[\e[m\] \W]\\$ "
-	[root@localhost]# usbguard generate-policy -X
-	[root@localhost]# usbguard generate-policy -X > /etc/usbguard/rules.conf
-	[root@localhost]# chmod 0600 /etc/usbguard/rules.conf
-	[root@localhost]# systemctl enable usbguard --now
-	[root@localhost]# usbguard list-rules
+. On *usbguard-demo*, invoke the following commands to generate a USBGuard policy, enable USBGuard, and list the rules:
++
+----
+[root@localhost ~]# export PS1="[\u@\[\e[41m\]\h\[\e[m\] \W]\\$ "
+[root@localhost]# usbguard generate-policy -X
+[root@localhost]# usbguard generate-policy -X > /etc/usbguard/rules.conf
+[root@localhost]# chmod 0600 /etc/usbguard/rules.conf
+[root@localhost]# systemctl enable usbguard --now
+[root@localhost]# usbguard list-rules
+----
 
-. Attach a USB drive to show what blocking means. You can see the device in the USB tree, but it will not be available to be mounted. The native usbguard tools will see the device and show the current action for it.
+. Attach a USB drive to see the effect of a blocking policy.
++
+You can see the device in the USB tree, but it is not available for mounting. The native USBGuard tools see the device and show the current action for it.
 
-. Open a seperate terminal and repeat the steps above in Lab 5.1.1 to login to the  *host* , *usbguard.example.com* virtual machine as root.
+. Open a separate terminal shell and repeat the steps in the <<Logging in to the *usbguard-demo* VM>> section to log in to the *host* *usbguard.example.com* VM as *root*.
 
-. On host:
+. On *host*, invoke the following:
++
+----
+[root@usbguard]# hostname
+usbguard
+[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk.img bs=1M count=32
+[root@usbguard]# virsh attach-device usbguard-demo usb-disk.xml
+----
 
-	[root@usbguard]# hostname
-	usbguard
-	[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk.img bs=1M count=32
-	[root@usbguard]# virsh attach-device usbguard-demo usb-disk.xml
+. On *usbguard-demo*, invoke the following:
++
+----
+[root@localhost]# lsusb
+[root@localhost]# lsblk
+[root@localhost]# usbguard list-devices
+[root@localhost]# usbguard list-devices --blocked
+----
++
+USBGuard allows administrators to dynamically change the action on a specific device.
 
-. On usbguard-demo:
+. On *usbguard-demo*, change the policy on the USB drive and see that it becomes available for mounting when allowed:
++
+----
+[root@localhost]# usbguard list-devices --blocked
+  11: block id 46f4:0001 serial "RED" name "QEMU USB HARDDRIVE" hash "AKmuakTNktSfF54t2IHFRMaukoUw47v3lu/9ZebOsNo=" parent-hash "CsKOZ6IY8v3eojsc1fqKDW84V+MMhD6HsjjojcZBjSg=" via-port "1-2" with-interface 08:06:50
+----
++
+[IMPORTANT]
+====
+The device number, `*11*` in this output, may be different from your output. Make sure to use the number that is in your output in the following commands.
+====
++
+----
+[root@localhost]# usbguard allow-device 11
+[root@localhost]# usbguard list-devices
+[root@localhost]# usbguard list-rules
+[root@localhost]# lsblk
 
-	[root@localhost]# lsusb
-	[root@localhost]# lsblk
-	[root@localhost]# usbguard list-devices
-	[root@localhost]# usbguard list-devices --blocked
+[root@localhost]# usbguard block-device 11
+[root@localhost]# usbguard list-devices
+----
++
+Setting `dynamic block` and `allow` works in the current boot, but they do not survive a reboot. To make the policy settings permanent, you must update the policy in `/etc/usbguard/rules.conf`.
 
-. USBGuard allows admins to dynamically change the action on a specific device.  Now let's change the policy on the USB drive and see that it becomes available for mounting when allowed.
+=== 5.5.1: Creating USBGuard Permanent Policy
 
-. On usbguard-demo:
+. On *usbguard-demo*, use the same dynamic commands to create a permanent entry in addition to immediate action using the `-p` option:
++
+----
+[root@localhost]# usbguard allow-device -p 11
+[root@localhost]# usbguard list-rules
+[root@localhost]# cat /etc/usbguard/rules.conf
 
-	[root@localhost]# usbguard list-devices --blocked
-    11: block id 46f4:0001 serial "RED" name "QEMU USB HARDDRIVE" hash "AKmuakTNktSfF54t2IHFRMaukoUw47v3lu/9ZebOsNo=" parent-hash "CsKOZ6IY8v3eojsc1fqKDW84V+MMhD6HsjjojcZBjSg=" via-port "1-2" with-interface 08:06:50
+[root@localhost]# usbguard block-device -p 11
+[root@localhost]# usbguard list-rules
 
-__Please note that the device number (`*11*:` in the output above) might be different. If so, make sure you use that number in the commands below.__
+[root@localhost]# usbguard allow-device -p 11
+[root@localhost]# usbguard list-rules
+----
 
-	[root@localhost]# usbguard allow-device 11
-	[root@localhost]# usbguard list-devices
-	[root@localhost]# usbguard list-rules
-	[root@localhost]# lsblk
+=== 5.5.2: (Optional) Testing USBGuard Policy for Multiple USB Devices
 
-	[root@localhost]# usbguard block-device 11
-	[root@localhost]# usbguard list-devices
-	[root@localhost]# lsblk
-
-While dynamic block and allow is a very nice feature, these don’t survive a reboot.  The more powerful use comes from setting permanent policy in `/etc/usbguard/rules.conf`.
-
-=== Lab 5.1.3 USBGuard permanent policy
-
-. The same dynamic command can create a permanent entry in combination with an immediate action using the `-p` option.
-
-. On usbguard-demo:
-
-	[root@localhost]# usbguard allow-device -p 11
-	[root@localhost]# usbguard list-rules
-	[root@localhost]# cat /etc/usbguard/rules.conf
-
-	[root@localhost]# usbguard block-device -p 11
-	[root@localhost]# usbguard list-rules
-
-	[root@localhost]# usbguard allow-device -p 11
-	[root@localhost]# usbguard list-rules
-
-=== Lab 5.1.4 USBGuard policy for multiple USB devices
-
-. OPTIONAL: The policy has been created for a very specific device.  Test that other USB devices will be blocked by adding a second USB drive from the host.  The _hash_ is calculated by USBGuard to identify individual devices.
-
-
-. On host:
-
-	[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk-2.img bs=1M count=32
-	[root@usbguard]# virsh attach-device usbguard-demo usb-disk-2.xml
-
-On usbguard-demo:
-
-	[root@localhost]# usbguard list-devices
+This policy was created for a specific device. In this section, you test whether other USB devices are blocked by adding a second USB drive from the host. The _hash_ is calculated by USBGuard to identify individual devices.
 
 
-=== Lab 5.1.5 Reject USB device(s) via USBGuard policy
+. On *host*, run the following to create and attach a USB disk:
++
+----
+[root@usbguard]# dd if=/dev/zero of=/tmp/usb-disk-2.img bs=1M count=32
+[root@usbguard]# virsh attach-device usbguard-demo usb-disk-2.xml
+----
 
-Policies built to allow or block specific devices is very good where devices can be vetted and identified.  For other environments, more flexible rules based on device characteristics are useful.  Blocking devices in this environment may not be strict enough.  We can also reject devices, which will tell the kernel to remove the device from the system.  A rejected device will not be visible in the output of `lsusb`, `usbguard list-devices`, nor in the `/sys/bus/usb/devices` tree.
+. On *usbguard-demo*, execute the following:
++
+----
+[root@localhost]# usbguard list-devices
+----
 
-. Generate a new base policy with the `reject` action.
+=== 5.5.3: Rejecting USB Device via USBGuard Policy
 
-. On host:
+Policies built to allow or block specific devices are useful when devices can be vetted and identified. For other environments, more flexible rules based on device characteristics are useful. Blocking devices in this environment may not be strict enough. You can also reject devices, which tells the kernel to remove the device from the system. A rejected device is not visible in the output of `lsusb`, `usbguard list-devices` or in the `/sys/bus/usb/devices` tree.
 
-	[root@usbguard]# virsh detach-device usbguard-demo usb-disk.xml
+In this section, you generate a new base policy with the `reject` action. You also investigate how the `reject` action differs from the `block` action. The journal records the kernel action as well as the USBguard action.
 
-. On usbguard-demo:
+. On *host*, run the following:
++
+----
+[root@usbguard]# virsh detach-device usbguard-demo usb-disk.xml
+----
 
-	[root@localhost]# systemctl stop usbguard
-	[root@localhost]# usbguard generate-policy -X -t reject > /etc/usbguard/rules.conf
-	[root@localhost]# cat /etc/usbguard/rules.conf
-	[root@localhost]# systemctl start usbguard
-	[root@localhost]# usbguard list-rules
+. On *usbguard-demo*, invoke the following:
++
+----
+[root@localhost]# systemctl stop usbguard
+[root@localhost]# usbguard generate-policy -X -t reject > /etc/usbguard/rules.conf
+[root@localhost]# cat /etc/usbguard/rules.conf
+[root@localhost]# systemctl start usbguard
+[root@localhost]# usbguard list-rules
+----
 
-. Show how the `reject` action differs from the `block` action. The journal records the kernel action as well as the USBguard action. You can highlight the entries in the logs.
+. On *host*, execute the following:
++
+----
+[root@usbguard]# virsh attach-device usbguard-demo usb-disk.xml
+----
 
-. On host:
+. On *usbguard-demo*, run the following and examine the highlighted the entries in the logs:
++
+----
+[root@localhost]# lsusb
+[root@localhost]# lsblk
+[root@localhost]# journalctl -b -e
 
-	[root@usbguard]# virsh attach-device usbguard-demo usb-disk.xml
-
-. On usbguard-demo:
-
-	[root@localhost]# lsusb
-	[root@localhost]# lsblk
-	[root@localhost]# journalctl -b -e
-
-. Notice the *Device is not authorized* line on the journalctl output. As mentioned before, the journal records the kernel action as well as the USBguard action.
+----
 +
 image:images/lab5.1.5-reject.png[500,500]
-
-. Now, remove the USBGuard rules configuration file and exit.
-
-    	[root@localhost]# rm /etc/usbguard/rules.conf
-    	[root@localhost]# exit
++
+Note the *Device is not authorized* line on the `journalctl` output. As mentioned before, the journal records the kernel action as well as the USBguard action.
 
 
-=== Lab 5.1.6 (Optional) Reset VM steps
-If you wanted to start this lab exercise from scratch, you can go through these reset VM steps.
+. Remove the USBGuard rules configuration file and exit:
++
+----
+[root@localhost]# rm /etc/usbguard/rules.conf
+[root@localhost]# exit
+----
 
-On host:
+=== 5.5.4: (Optional) Resetting VM Steps
+If you want to start this lab from scratch, make sure to perform these reset VM steps.
 
-    [root@usbguard]# virsh detach-device usbguard-demo usb-disk.xml
-    [root@usbguard]# virsh detach-device usbguard-demo usb-disk-2.xml
-    [root@usbguard]# virsh destroy 1
+. On *host*, invoke the following:
++
+----
+[root@usbguard]# virsh detach-device usbguard-demo usb-disk.xml
+[root@usbguard]# virsh detach-device usbguard-demo usb-disk-2.xml
+[root@usbguard]# virsh destroy 1
+----
 
 <<top>>
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab6_Audit.adoc[ Lab 6: Audit ]
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab6_Audit.adoc[Lab 6: Audit^]
+

--- a/2020Labs/RHELSecurity/documentation/lab6_Audit.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab6_Audit.adoc
@@ -1,453 +1,544 @@
+:toc2:
+:linkattrs:
+
 = Lab 6: Auditing on Red Hat Enterprise Linux 8
 
-*Lab Length: Medium/Average (~15 mins)*
+.*Lab Length*
+* Medium/Average (~15 mins)
 
-== Goal of Lab
+.*Goal*
+* Become familiar with the auditing capabilities of Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL)
 
-The following lab is an introduction to the auditing capabilities of Red Hat Enterprise Linux. The exercises below are done on a system installed with Red Hat Enterprise Linux 8, and may require modification to work in other lab environments.
+== 6.1: Introduction
+The Linux Audit System provides a way to track security-relevant information on your system. Based on preconfigured rules, Audit generates log entries to record as much information as possible about the events happening on your system. This information is crucial for mission-critical environments to determine any violations of security policy and what actions the violator performed. Audit does not provide additional security to your system; rather, it can be used to discover violations of security policies used on your system. These violations can be prevented by additional security measures such as SELinux.
 
-== Introduction
-The Linux Audit system provides a way to track security-relevant information on your system. Based on pre-configured rules, Audit generates log entries to record as much information about the events that are happening on your system as possible. This information is crucial for mission-critical environments to determine the violator of the security policy and the actions they performed. Audit does not provide additional security to your system; rather, it can be used to discover violations of security policies used on your system. These violations can further be prevented by additional security measures such as SELinux.
+The lab is performed on a system installed with Red Hat Enterprise Linux 8 and may require modification to work in other lab environments.
 
-== Lab 6.1 Accessing the Audit Lab System
+== 6.2: Accessing the Audit Lab System
 
-All of the exercises in this lab are run on the _audit.example.com_ host,
-either as the *root* or *auditlab* user.  Each set of exercises instructs you
-about which user to use, and the username is reflected in the command prompt,
-as seen in the examples below:
+All of the exercises in this lab are run on the *audit.example.com* host,
+either as the *root* or *auditlab* user. In each section, you are instructed which user to use. The username is reflected in the command prompt as shown here:
 
-* The *root* user prompt on _audit.example.com_
-
-	[root@audit ~]#
-
-* The *auditlab* user prompt on _audit.example.com_
-
-	[auditlab@audit ~]$
-
-The recommended way to access the _audit.example.com_ is to open up the terminal and SSH into the
-_audit.example.com_ host from the bastion workstation system as shown below.  If done
-correctly, you should not need to enter a password.
-
-
-* First, SSH command to login to the bastion workstation system, replacing GUID with your lab's GUID.
-
-	[localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
-
-* then SSH command to login to _audit.example.com_ as *root*.
-
-	[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
-
-* to avoid the need to exit your root session on _audit.example.com_ repeat the first SSH command to login to your bastion workstation system in a new terminal, then SSH command to login to _audit.example.com_ as "auditlab"
-
-	[lab-user@workstation-GUID ~]$ ssh auditlab@audit.example.com
-
-== Lab 6.2 Configuring Audit
-
-There are two main audit components in Red Hat Enterprise Linux, the audit
-daemon and the kernel itself.  The exercises below demonstrate how to configure
-both.
-
-=== Lab 6.2.1 Audit Daemon Configuration
-
-==== Introduction
-When the audit daemon is started during the boot process, it reads the
-configuration file in _/etc/audit/auditd.conf_.  The different configuration options are explained in the
-http://man7.org/linux/man-pages/man5/auditd.conf.5.html[auditd.conf(5)]
-manpage.  Three of the more interesting options are the *flush*, *freq*, and *log_format* options:
-
-* *flush* determines the method how the audit events are flushed to disk.
-* *freq* controls how frequently the flush happens.
-* *log_format* option controls the on-disk audit log format.
-
-For this lab, we will check to ensure that *flush*  is set to *INCREMENTAL_ASYNC*
-(asynchronous flushing for performance), *freq* is set to 50 (flush the log
-every 50 records), and *log_format* is set to “ENRICHED” (resolves some
-information for improved archival value).
-
-The _/etc/audit/auditd.conf_ file
-can be modified using any text editor; but in this lab we will use the `sed` command to edit the _auditd.conf_ file.
-
-==== Lab 6.2.1 exercise steps
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+* The *root* user prompt on *audit.example.com*:
 +
-[source]
+----
+[root@audit ~]#
+----
+
+* The *auditlab* user prompt on *audit.example.com*:
++
+----
+[auditlab@audit ~]$
+----
+
+To access the *audit.example.com*, Red Hat recommends that you open the terminal and
+remotely connect using SSH into the *audit.example.com* host from the bastion
+workstation system as shown. If done correctly, you do not need to enter
+a password.
+
+. Use SSH to remotely log in to the bastion workstation system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
++
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *audit.example.com* host as *root*.
+. Use SSH to remotely log in to *audit.example.com* as *root*:
++
+----
+[lab-user@workstation-GUID ~]$ ssh root@audit.example.com
+----
+
+. Repeat the first SSH command to log in to your bastion workstation system in a new terminal, then use SSH to log in to *audit.example.com* as `auditlab` to avoid exiting your root session on *audit.example.com*:
++
+----
+[lab-user@workstation-GUID ~]$ ssh auditlab@audit.example.com
+----
+
+== 6.3: Configuring the Audit Daemon and Kernel
+
+There are two main audit components in Red Hat Enterprise Linux: the audit
+daemon and the kernel itself. In this section, you configure both.
+
+=== 6.3.1: Configuring the Audit Daemon
+
+When the audit daemon is started during the boot process, it reads its
+configuration information from the file `/etc/audit/auditd.conf`.
+The configuration options are explained in the link:http://man7.org/linux/man-pages/man5/auditd.conf.5.html[auditd.conf(5)^]
+man page. Three of the more interesting options are the `flush`, `freq`, and `log_format` options:
+
+* `flush` determines the method by which audit events are flushed to disk.
+* `freq` controls how frequently the flush takes place.
+* `log_format` option controls the on-disk audit log format.
+
+In this section, you verify that `flush` is set to `INCREMENTAL_ASYNC`
+(for asynchronous flushing for performance), *freq* is set to `50` (to flush the log
+every 50 records), and *log_format* is set to `ENRICHED` (to resolve some
+information for improved archival value).
+
+The `/etc/audit/auditd.conf` file
+can be modified using any text editor. In this section, you use the `sed` command to edit the file.
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and, if needed, using *r3dh4t1!* as the password):
++
+----
+[localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
+
+. Log in to the *audit.example.com* host as *root*:
 +
 [source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@audit.example.com
 ----
-. While logged into the _audit.example.com_ system as *root*, run the following commands to edit the
-_auditd.conf_ file:
 
-	[root@audit ~]# sed -e 's/^flush.*/flush = INCREMENTAL_ASYNC/' -i /etc/audit/auditd.conf
-	[root@audit ~]# sed -e 's/^freq.*/freq = 50/' -i /etc/audit/auditd.conf
-	[root@audit ~]# sed -e 's/^log_format.*/log_format = ENRICHED/' -i /etc/audit/auditd.conf
-
-. After the configuration file has been updated, we need to signal to the audit
-daemon to reload its configuration.  While logged into the _audit.example.com_
-system as *root*, run the following command to force `auditd` to reload its
-configuration:
-
-	[root@audit ~]# service auditd reload
+. As *root*, edit the `auditd.conf` file:
 +
-It should come back with an acknowledgement such as:
-
-	Reconfiguring: [  OK  ]
-
-. The audit daemon can dump a small report about its configuration and some facts about
-its current state. This can help you diagnose problems that the audit daemon has run into.
-As *root*, run the following command:
-
-	[root@audit ~]# service auditd state
+----
+[root@audit ~]# sed -e 's/^flush.*/flush = INCREMENTAL_ASYNC/' -i /etc/audit/auditd.conf
+[root@audit ~]# sed -e 's/^freq.*/freq = 50/' -i /etc/audit/auditd.conf
+[root@audit ~]# sed -e 's/^log_format.*/log_format = ENRICHED/' -i /etc/audit/auditd.conf
+----
 +
-It should come back with an acknowledgement such as:
+After the configuration file is updated, you must signal the audit
+daemon to reload its configuration.
 
-	Getting auditd internal state: [  OK  ]
+. As *root*, force `auditd` to reload its configuration:
 +
-and a list of values including the current time, process priority, configuration options, disk free, etc...
+----
+[root@audit ~]# service auditd reload
+----
++
+Expect to see it return an acknowledgement similar to:
++
+----
+Reconfiguring: [  OK  ]
+----
++
+The audit daemon can dump a small report about its configuration and some facts about
+its current state. This can help you diagnose problems encountered by the audit daemon.
 
-. Normally the audit daemon enables the kernel's audit subsystem. To verify that the audit
-system is enabled, we can run the following command as *root* to get the kernel's state:
+. As *root*, determine the audit daemon's state:
++
+----
+[root@audit ~]# service auditd state
+----
++
+Expect to see it return an acknowledgement similar to the following, with a list of values including the current time, process priority, configuration options, and disk free space:
++
+----
+Getting auditd internal state: [  OK  ]
+----
++
+Usually the audit daemon enables the kernel's audit subsystem.
 
+. As *root*, get the kernel's state to verify that the audit system is enabled:
++
+----
 	[root@audit ~]# auditctl -s
+----
 +
-The first line output should tell you if its enabled. A one means it's enabled.  The pid line is the PID of the audit daemon.  The rest is the kernel status not including rules.
+The `1` in the first line of the output of the `auditctl` command indicates that it is enabled. The `pid` line provides the PID of the audit daemon. The rest of the output is the kernel status, not including rules.
 
-=== Lab 6.2.2 Linux Kernel Configuration
+=== 6.3.2: Configuring the Linux Kernel
 
-The Linux Kernel’s audit subsystem can be configured using the `auditctl`
-command.  Using `auditctl` the administrator can add audit event filtering
-rules as well as tune the audit subsystem in the kernel.  The different
-configuration parameters are explained in the
-http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)] manpage.
+The Linux kernel’s audit subsystem can be configured with the `auditctl`
+command. By using `auditctl` the administrator can add audit event filtering
+rules as well as tune the audit subsystem in the kernel. The configuration
+parameters are explained in the
+link:http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)^] man page.
 
-==== Lab 6.2.2.1 Pre-Configured Rules
+==== 6.3.2.1: Enabling Preconfigured Rules
 
-A number of pre-configured audit filter rules are provided with Red Hat
-Enterprise Linux. They can be found in _/usr/share/doc/audit-*_.  These filter
+A number of preconfigured audit filter rules are provided with Red Hat
+Enterprise Linux. You can find them in `/usr/share/doc/audit-*`. These filter
 rules can be enabled by copying them to the system’s audit filter rule
 directory, regenerating the filter configuration, and loading the resulting
-filter rule configuration into the kernel.  
+filter rule configuration into the kernel.
 
-In the exercise below, we will enable
-some basic audit filters designed to help administrators meet the US Department of Defense Security
+In this section, you enable some basic audit filters designed to help
+administrators meet the U.S. Department of Defense Security
 Technical Implementation Guide (STIG) for Red Hat Enterprise Linux.
 
-. While
-logged into the _audit.example.com_ system as *root*, run the following commands
-to enable a number of pre-defined audit filters:
-
-	[root@audit ~]# cat /usr/share/doc/audit/rules/README-rules
-	[root@audit ~]# rm /etc/audit/rules.d/*
-	[root@audit ~]# cp /usr/share/doc/audit/rules/10-base-config.rules /etc/audit/rules.d
-	[root@audit ~]# cp /usr/share/doc/audit/rules/30-stig.rules /etc/audit/rules.d
-	[root@audit ~]# cp /usr/share/doc/audit/rules/31-privileged.rules /etc/audit/rules.d
-	[root@audit ~]# cp /usr/share/doc/audit/rules/99-finalize.rules /etc/audit/rules.d
-	[root@audit ~]# augenrules --load
-
+. While logged in to the *audit.example.com* system as *root*, enable a number of
+pre-defined audit filters:
 +
-The `augenrules` tool combines all of the _*.rules_ files located in
-_/etc/audit/rules.d_ into the _/etc/audit/audit.rules_ file and loads them
-using the `auditctl` command.  You can remove, or rename, any of these files
+----
+[root@audit ~]# cat /usr/share/doc/audit/rules/README-rules
+[root@audit ~]# rm /etc/audit/rules.d/*
+[root@audit ~]# cp /usr/share/doc/audit/rules/10-base-config.rules /etc/audit/rules.d
+[root@audit ~]# cp /usr/share/doc/audit/rules/30-stig.rules /etc/audit/rules.d
+[root@audit ~]# cp /usr/share/doc/audit/rules/31-privileged.rules /etc/audit/rules.d
+[root@audit ~]# cp /usr/share/doc/audit/rules/99-finalize.rules /etc/audit/rules.d
+[root@audit ~]# augenrules --load
+----
++
+The `augenrules` tool combines all of the `*.rules` files located in
+`/etc/audit/rules.d` into the `/etc/audit/audit.rules` file and loads them
+using the `auditctl` command. You can remove or rename any of these files
 and rerun the `augenrules --load` command to reconfigure your system.
 
-. Now that we have loaded some rules, let's have the kernel dump the currently loaded rules so
-that we can inspect what was loaded. As *root*, run the following command and observe its output:
-
-	[root@audit ~]# auditctl -l
+. Now that rules are loaded, working as *root*, have the kernel dump the currently loaded rules so
+that you can inspect what is loaded:
 +
-You should see many audit rules output from the kernel.
+----
+[root@audit ~]# auditctl -l
+----
++
+Expect to see many audit rules output from the kernel.
 
-==== Lab 6.2.2.2 Custom Rules
+==== 6.3.2.2: Creating Custom Rules
 
-===== Introduction
 Custom audit filters can be loaded into the kernel using the `auditctl`
-command.  The different filter options are explained in the
-http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)] manpage.
+command. The various filter options are explained in the
+link:http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)^] man page.
 
 Custom audit filters can be made persistent by creating a new file in the
-_/etc/audit/rules.d_ directory with the _.rules_ file extension.  While not
+`/etc/audit/rules.d` directory with the `.rules` file extension. While not
 required, the following naming convention is suggested:
 
-	<priority>-<name>.rules
+----
+<priority>-<name>.rules
+----
 
-Where the “<priority>” value falls into these categories:
+Where the `<priority>` value falls into these categories:
 
-	10: Kernel and auditctl configuration
-	20: Rules that could match general rules but we want a different match
-	30: Main rules
-	40: Optional rules
-	50: Server Specific rules
-	70: System local rules
-	90: Finalize (immutable)
+----
+10: Kernel and `auditctl` configuration
+20: Rules that could match general rules but we want a different match
+30: Main rules
+40: Optional rules
+50: Server specific rules
+70: System local rules
+90: Finalize (immutable)
+----
 
-The pre-configured filter rules provide a great example for how to structure
-your custom audit filter rule files, but the basic syntax is that each line is
+The preconfigured filter rules provide a useful example for how to structure
+your custom audit filter rule files. The basic syntax is that each line is
 a series of arguments passed to the `auditctl` command; lines starting with a
-“#” are treated as comments and ignored.
+`#` are treated as comments and ignored.
 
-===== Lab 6.2.2.2 exercise steps
-In
-the exercise below, we are going to create an audit filter that will capture audit
-events created by the `/usr/bin/ping` program.  We will also configure the
-system to tag all of those events with the *rhkey* key, using the *-k*
-option, to make search through the audit log easier.  The *-a always,exit* is
-a common way to add audit filter rules, it adds a filter rule to be executed at
-syscall exit time, see the
-http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)] manpage for
-more detail.
+In this section, you create an audit filter that captures audit
+events created by the `/usr/bin/ping` program. You also configure the
+system to tag all of those events with the `rhkey` key, using the `-k`
+option, to make the search through the audit log easier.  The `-a always,exit` is
+a common way to add audit filter rules; it adds a filter rule to be executed at
+`syscall` exit time. (See the
+link:http://man7.org/linux/man-pages/man8/auditctl.8.html[auditctl(8)^] man page for
+more detail.)
 
-. While logged into the _audit.example.com_ system as *root*, run the
-following commands to add a custom audit filter for the `/usr/bin/ping`
-application:
+. While logged into the *audit.example.com* system as *root*, add a custom audit
+filter for the `/usr/bin/ping` application:
++
+----
+[root@audit ~]# auditctl -a always,exit -F exe=/usr/bin/ping -k rhkey
+----
 
-	[root@audit ~]# auditctl -a always,exit -F exe=/usr/bin/ping -k rhkey
+. As *root*, add a new rule file to `/etc/audit/rules.d` and reload your configuration
+ to make your custom filter rule persistent:
++
+----
+[root@audit ~]# echo "-a always,exit -S all -F exe=/usr/bin/ping -F key=rhkey" > /etc/audit/rules.d/70-rhkey_lab.rules
+[root@audit ~]# augenrules --load
+----
++
+In addition to modifying custom filter rules, you can adjust the base configuration of the audit subsystem in the Linux kernel using `auditctl`.
 
-
-. We can make our custom filter rule persistent by adding a new rule file in
-_/etc/audit/rules.d_ and reloading our configuration.
-
-. While logged into the
-_audit.example.com_ system as *root*, run the following commands to make the
-custom filter rule persistent:
-
-	[root@audit ~]# echo "-a always,exit -S all -F exe=/usr/bin/ping -F key=rhkey" > /etc/audit/rules.d/70-rhkey_lab.rules
-	[root@audit ~]# augenrules --load
-
-. In addition to custom filter rules, this is also the mechanism we use to tweak
-the base configuration of the audit subsystem in the Linux Kernel.  While
-logged into the _audit.example.com_ system as *root*, run the following command
-to increase the audit backlog buffer to 8192 entries:
+. As *root*, increase the audit backlog buffer to `8192` entries:
 
 	[root@audit ~]# auditctl -b 8192
 +
-This setting will be confirmed by output similar to the status command.
-
-. If we wanted to make the configuration tweak persistent, we could create a new
-file in _/etc/audit/rules.d_ with the configuration and reload the audit rules.
-While logged into the _audit.example.com_ system as *root*, run the following
-commands to make the backlog changes persistent:
-
-	[root@audit ~]# echo "-b 8192" > /etc/audit/rules.d/15-rhkey_kernel.rules
-	[root@audit ~]# augenrules --load
-
-==== Lab 6.2.2.3 Kernel boot parameters
-
-===== Introduction
-Additionally, the kernel has two kernel boot command line options that affect the audit system:
-*audit* and *audit_backlog_limit*. The audit configuration option takes either a 1 or 0 which
-means enabled or disabled respectively. If you plan to use to the audit system, you should boot
-with audit enabled. As the system is booting, it will be generating events. By default the kernel
-has room to hold 64 events. But systemd logs an event for every service started and stopped, and
-the kernel logs events as it gets configured. This can easily overrun the 64 reserved event spots.
-So, what we want to do is increase the backlog to hold a lot of events until auditd can start
-reading them.
-
-===== Lab 6.2.2.3 exercise steps
-
-In the steps below, we will modify _/etc/default/grub_ to add audit related configuration to the
-kernel's boot prompt. We will then regenerate the boot menu so that it takes effect.
-
-. As *root* run the following command:
-
-	[root@audit ~]# cp /etc/default/grub /etc/default/grub.bak
-	[root@audit ~]# sed -e '/GRUB_CMDLINE_LINUX/s/\"/ audit=1 audit_backlog_limit=8192\"/2' -i /etc/default/grub
+This setting is confirmed by output similar to the status command.
 +
-To verify, the addition "audit=1 audit_backlog_limit=8192" should be visible with the following command:
+If you want to make the configuration change persistent, you can
+create a new file in `/etc/audit/rules.d` with the configuration and reload the
+audit rules.
 
-	[root@audit ~]# grep GRUB_CMDLINE_LINUX /etc/default/grub
+. As *root*, make the backlog changes persistent:
++
+----
+[root@audit ~]# echo "-b 8192" > /etc/audit/rules.d/15-rhkey_kernel.rules
+[root@audit ~]# augenrules --load
+----
 
-. Next we need to regenerate the grub boot menu. The menu is in different places based on whether
-you have a BIOS based machine or a UEFI based machine. But we can find the file we need to
-replace with a `find` command. As *root*, run the following command:
+==== 6.3.2.3: Defining Kernel Boot Parameters
 
-	[root@audit ~]# grub2-mkconfig -o `find /boot -name grub.cfg`
+The kernel also has two kernel boot command-line options that affect the audit system:
+`audit` and `audit_backlog_limit`. The `audit` configuration option takes either a `1` or `0`, which
+means enabled or disabled, respectively. If you plan to use the audit system, you should boot
+with `audit` enabled. As the system is booting, it generates events. By default the kernel
+has room to hold 64 events. But `systemd` logs an event for every service started and stopped, and
+the kernel logs events as it gets configured. This can easily overrun the 64 reserved event spots.
+To hold a lot of events until `auditd` can start reading them, you increase the backlog.
 
+In this section, you modify `/etc/default/grub` to add audit-related configuration to the
+kernel's boot prompt. Then you regenerate the boot menu so that it takes effect.
 
-== Lab 6.3 Inspecting Audit Logs
+. As *root*, back up the current `/etc/default/grub` file and edit it to set the `audit` and `audit_backlog_limit` options:
++
+----
+[root@audit ~]# cp /etc/default/grub /etc/default/grub.bak
+[root@audit ~]# sed -e '/GRUB_CMDLINE_LINUX/s/\"/ audit=1 audit_backlog_limit=8192\"/2' -i /etc/default/grub
+----
+
+. Verify that the `audit=1 and audit_backlog_limit=8192` options are present:
++
+----
+[root@audit ~]# grep GRUB_CMDLINE_LINUX /etc/default/grub
+----
+
+. As *root*, regenerate the grub boot menu:
++
+----
+[root@audit ~]# grub2-mkconfig -o `find /boot -name grub.cfg`
+----
+* The menu is in different places based on whether you have a BIOS- or UEFI-based machine. The `find` command locates the file for you.
+
+== 6.4: Inspecting the Audit Log
 
 The exercises below show how to search through the audit logs and generate
-summary audit reports.  It is important to note that this section requires that
+summary audit reports. It is important to note that this section requires that
 the system is configured as described earlier in this lab.
 
-=== Lab 6.3.1 Generate Audit Events
+=== 6.4.1: Generating Audit Events
 
-In order to ensure we have some interesting events in the audit log, open up another terminal and from the
-workstation bastion host, login to the _audit.example.com_ system as the *auditlab*
-user and run the following commands:
+. Open another terminal shell on the workstation bastion host, and from there log in to the
+*audit.example.com* system as the *auditlab* user:
++
+----
+[lab-user@workstation-GUID ~]$ ssh auditlab@audit.example.com
+----
 
-	[lab-user@workstation-GUID ~]$ ssh auditlab@audit.example.com
+. Run the following commands to generate some interesting events in the audit log:
++
+----
+[auditlab@audit ~]$ vi /etc/shadow
+(Type :q! to exit vi)
+----
++
+----
+[auditlab@audit ~]$ ping -c 1 127.0.0.1
+----
++
+----
+[auditlab@audit ~]$ vi ~/project_tps_report.txt
+(Type: i to go into insert mode)
+(Type: This is my TPS report)
+(Press *Esc*)
+(Type :wq! to save the file and exit vi)
+----
++
+----
+[auditlab@audit ~]$ chmod 0664 ~/project_tps_report.txt
+----
 
-	[auditlab@audit ~]$ vi /etc/shadow
-	(Type :q! to exit vi)
+=== 6.4.2: Searching for Events
 
-	[auditlab@audit ~]$ ping -c 1 127.0.0.1
-
-	[auditlab@audit ~]$ vi ~/project_tps_report.txt
-	(Type: i to go into insert mode)
-	(Type: This is my TPS report)
-	(Press *Esc*)
-	(Type :wq! to save the file and exit vi)
-
-	[auditlab@audit ~]$ chmod 0664 ~/project_tps_report.txt
-
-=== Lab 6.3.2 Searching for Events
-
-While the audit logs are plaintext files, and normal Linux text searching tools
+While the audit logs are plain text files, and normal Linux text searching tools
 (e.g. `grep`) can be used to search the audit logs, the audit userspace tools
-include a tool specially designed to search and interpret the audit logs,
-`ausearch`.  The `ausearch` tool can take a number of command line parameters,
-all of which are described in the
-http://man7.org/linux/man-pages/man8/ausearch.8.html[ausearch(8)] manpage.
+include `ausearch`&#8212;, which was designed to search and interpret the audit logs.
+The `ausearch` tool can take a number of command-line parameters, which are described in the
+link:http://man7.org/linux/man-pages/man8/ausearch.8.html[ausearch(8)^] man page.
 
-The *--start* option specifies at what point in the audit logs to start searching,
-*--start today* indicates that only events from today should be considered.  The
-*-m* option indicates that you are interested in audit events with the given
+The `--start` option specifies at what point in the audit logs to start searching,
+`--start today` indicates that only events from today should be considered. The
+`-m` option indicates that you are interested in audit events with the given
 record type.
 
-. While logged into the _audit.example.com_ system as *root*, run the
-following commands to see the login events on the test system:
-
-	[root@audit ~]# ausearch --start today -m USER_LOGIN
+. While logged into the *audit.example.com* system as *root*, examine the login events on the test system:
 +
-There should be at least one event shown with sshd for the current session that is hosting this search command.
-
-. Multiple record types can be specified, the results include events which
-contain either record type.  While logged into the _audit.example.com_ system
-as *root*, run the following command to see all of the service start and stop
-events:
-
-	[root@audit ~]# ausearch --start this-month -m SERVICE_START -m SERVICE_STOP
+----
+[root@audit ~]# ausearch --start today -m USER_LOGIN
+----
 +
-The output should show an event for each service run or stopped in that time.
+Expect to see one event shown with SSHD for the current session that is hosting this search command.
 
-. The *-i* option instructs `ausearch` to interpret the results, translating some
-fields into a more human readable form.  The *-k* option searches on the key
+. As *root*, list all of the service start and stop events:
++
+----
+[root@audit ~]# ausearch --start this-month -m SERVICE_START -m SERVICE_STOP
+----
++
+Multiple record types can be specified; the results include events that
+contain either record type.
++
+Expect the results to show an event for each service run or stopped in that time.
++
+The `-i` option instructs `ausearch` to interpret the results, translating some
+fields into a more human-readable form. The `-k` option searches on the key
 assigned to an audit rule.
 
-. While logged into the _audit.example.com_ system as
-*root*, run the following command to see all events from today matching the
-*access* key:
-
-	[root@audit ~]# ausearch --start today -i -k access
+. As *root*, display all of the events from today matching the *access* key:
 +
-This will list any events that were triggered by the pre-defined rules with the key "access" and the "-i" interpretation option makes the proctitle field readable in the output.
-
-. The *--uid* option searches for events that match the given UID.
-. While logged
-into the _audit.example.com_ system as *root*, run the following command to see
-today's events from the *auditlab* user that match the *perm_mod* key:
-
-	[root@audit ~]# ausearch --start today -i -k perm_mod --uid auditlab
+----
+[root@audit ~]# ausearch --start today -i -k access
+----
 +
-This should list the event generated by the example above in section 6.3.1.
+This command lists any events triggered by the pre-defined rules with the `access` key, and the `-i` interpretation option makes the `proctitle` field readable in the output.
 
-. The *-f* option searches for events that match on the given file name.
-. While
-logged into the _audit.example.com_ system as *root*, run the following command
-to see all of today's accesses of the *project_tps_report.txt* file:
-
-	[root@audit ~]# ausearch --start today -i -f project_tps_report.txt
+. As *root*, display today's events from the *auditlab* user that match the `perm_mod` key:
 +
-This should list the creation and permission modification events from example 6.3.1.
-
-. Finally, we can search for audit events generated by our custom filter rule.
-. While logged into the _audit.example.com_ system as *root*, run the following
-command to see all events from today matching the *rhkey* key:
-
-	[root@audit ~]# ausearch --start today -i -k rhkey
+----
+[root@audit ~]# ausearch --start today -i -k perm_mod --uid auditlab
+----
 +
-This should list the event from the ping command in example 6.3.1.
+The `--uid` option searches for events that match the given UID.
++
+Expect this command to list the event generated by the example above in the <<Audit Events Generation>> section.
 
-=== Lab 6.3.3 Generating Reports
+. As *root*, display all of today's accesses of the *project_tps_report.txt* file:
++
+----
+[root@audit ~]# ausearch --start today -i -f project_tps_report.txt
+----
++
+The `-f` option searches for events that match the given file name.
++
+Expect the command to list the creation and permission modification events from the <<Audit Events Generation>> section.
 
-Included in the audit userspace tools are three utilities which can be used to
+. As *root*, view all of the events from today matching the `rhkey` key, to search for audit events generated by your custom filter rule:
++
+----
+[root@audit ~]# ausearch --start today -i -k rhkey
+----
++
+Expect this to list the event from the `ping` command in the <<Audit Events Generation>> section.
+
+=== 6.4.3: Generating Reports
+
+Included in the Audit userspace tools are three utilities that can be used to
 generate a number of reports from the audit log: `aureport`, `aulast`, and
 `aulastlog`.  The `aureport` tool can generate a number of different reports,
 all of which are described in the
-http://man7.org/linux/man-pages/man8/aureport.8.html[aureport(8)] manpage.
+link:http://man7.org/linux/man-pages/man8/aureport.8.html[aureport(8)^] man page.
 
-. While logged into the _audit.example.com_ system as *root*, run the following
+. While logged into the *audit.example.com* system as *root*, run the following
 commands to create several audit reports for today's activity:
-
-	[root@audit ~]# aureport --start today --summary
-	[root@audit ~]# aureport --start today --summary -i --file
-	[root@audit ~]# aureport --start today --summary -i --executable
-	[root@audit ~]# aureport --start today --summary -i --login
-
-. The `aureport` and `ausearch` tools may be used together. Suppose you wanted to identify who was
-triggering a specific audit rule. The strategy is to search for the key that is associated and then
-feed the results to the kind of report you are interested in. This will only work if the output
++
+----
+[root@audit ~]# aureport --start today --summary
+[root@audit ~]# aureport --start today --summary -i --file
+[root@audit ~]# aureport --start today --summary -i --executable
+[root@audit ~]# aureport --start today --summary -i --login
+----
++
+The `aureport` and `ausearch` tools may be used together if you want to identify who triggered
+a specific audit rule. The strategy is to search for the key that is associated with the audit rule
+and then feed the results to the kind of report you are interested in. This works only if the output
 from `ausearch` is exactly as it is in the logs. To tell `ausearch` to leave the event unaltered,
-pass the *--raw* formatting option. As *root* run the following command:
+pass the `--raw` formatting option.
 
-	[root@audit ~]# ausearch --start today -k access --raw | aureport --summary -i --file
-
-. The `aulast` tool generates a report similar to the `last` command, except the
-information is collected from the audit log instead of the less reliable utmp
-logs.  The _aulast(8)_ manpage provides details on how to run `aulast`, without
-any options the output is familiar with the `last` command.
-
+. As *root*, run the following command:
++
+----
+[root@audit ~]# ausearch --start today -k access --raw | aureport --summary -i --file
+----
++
+The `aulast` tool generates a report similar to the `last` command, except the
+information is collected from the audit log instead of the less reliable `utmp`
+logs. The _aulast(8)_ man page provides details on how to run `aulast`; without
+any options, the output is familiar with the `last` command.
++
 The `aulast` utility can also help you find an `ausearch` command to extract just the audit
-events for a specific login whenever you pass the *--proof* command line option. This is helpful
-when investigating what programs or files a user accessed during a specific session.
+events for a specific login whenever you pass the `--proof` command-line option. This is helpful
+when investigating which programs or files a user accessed during a specific session.
 
-. While logged into
-the _audit.example.com_ system as *root*, run the following command to see an
-example of an `aulast` report:
-
-	[root@audit ~]# aulast
-	[root@audit ~]# aulast --proof
-
-. Similar to `aulast`, `aulastlog` is designed as a replacement for the `lastlog`
-command; the important difference being that `aulastlog` collects data from the
-audit log.  The _aulastlog(8)_ manpage provides more information, but running
+. As *root*, examine an example of `aulast` report:
++
+----
+[root@audit ~]# aulast
+[root@audit ~]# aulast --proof
+----
++
+Similar to `aulast`, `aulastlog` is designed as a replacement for the `lastlog`
+command--the important difference being that `aulastlog` collects data from the
+audit log. The _aulastlog(8)_ man page provides more information, but even running
 `aulastlog` without any options results in a useful report.
 
-. While logged into
-the _audit.example.com_ system as *root*, run the following command to see an
-example:
-
+. As *root*, examine an `aulastlog` report:
++
+----
 	[root@audit ~]# aulastlog
+----
 
-=== Lab 6.3.4 Transforming Audit Logs
+=== 6.4.4: Transforming Audit Logs
 
 In addition to searching through the audit logs, the `ausearch` tool can also
-be used to transform the results into different formats.  If you have already
-done the rest of this lab, you are most likely familiar with the default *raw*
-and the *interpreted* formats.  In addition to these formats, there are also
-*csv* and *text* formats which can be selected using the *--format* argument.
+be used to transform the results into different formats. If you have already
+completed the rest of this lab, you are most likely familiar with the `raw`
+and `interpreted` default formats. In addition to these formats, there are also
+`csv` and `text` formats, which can be selected using the `--format` argument.
 
-The *--format* option, as well as several others which can customize the output
+The `--format` option, as well as several others that can customize the output
 of `ausearch`, can be found in the
-http://man7.org/linux/man-pages/man8/ausearch.8.html[ausearch(8)] manpage.
+link:http://man7.org/linux/man-pages/man8/ausearch.8.html[ausearch(8)^] man page.
 
-. While logged into the _audit.example.com_ system as *root*, run the following
-commands to see samples of the *csv* and *text* formats:
-
-	[root@audit ~]# ausearch --start today --format csv
-	[root@audit ~]# ausearch --start today --format text
-
-. The *csv* output is particularly interesting as it can be imported into
+. While logged into the *audit.example.com* system as *root*, view samples of the `csv` and `text` formats:
++
+----
+[root@audit ~]# ausearch --start today --format csv
+[root@audit ~]# ausearch --start today --format text
+----
++
+The CSV output is particularly interesting as it can be imported into
 LibreOffice or any other spreadsheet program that accepts files in the
 Comma Separated Values (CSV) format.
 
-== Reset the Lab System (Optional)
+. As *root*, transform today's audit log into the CSV format suitable for use within LibreOffice:
++
+----
+[root@audit ~]# ausearch --start today --format csv --extra-labels --extra-obj2 > /tmp/audit.log.csv
+----
 
-If you wanted to re-do all of these audit lab exercises from scratch, you can reset your lab system. In order to reset the system used for this audit lab exercise, run the following commands as
-*root* on _audit.example.com_:
+=== 6.4.5: Viewing the CSV Output Audit Log from the Workstation Bastion Host
 
-	[root@audit ~]# rm /etc/audit/rules.d/*
-	[root@audit ~]# cp /usr/share/doc/audit/rules/10-base-config.rules /etc/audit/rules.d
-	[root@audit ~]# augenrules --load
-	[root@audit ~]# cp /etc/default/grub.bak /etc/default/grub
-	[root@audit ~]# grub2-mkconfig -o `find /boot -name grub.cfg`
+In this section, you transfer the CSV file you just created from the *audit.example.com* system to the workstation bastion host system by using `scp`. Then you open the CSV file using LibreOffice from the workstation bastion host.
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
++
+----
+[localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
+----
+
+. Use `scp` to transfer the CSV file from the *audit.example.com* system to the desktop of the workstation bastion host system:
++
+----
+[lab-user@workstation-GUID ~]$ scp root@audit.example.com:/tmp/audit.log.csv ~/Desktop/
+----
+
+. Return to your *Lab Information* web page and click *CONSOLE* for your workstation bastion host:
++
+image:images/lab1.1-workstationconsole.png[300,300]
+
+. Log in as *lab-user* with *r3dh4t1!* as the password:
++
+image:images/lab1.1-labuserlogin.png[300,300]
+
+. Locate the CSV file you just copied from the *audit.example.com* system on your workstation bastion host's desktop:
++
+image:images/audit-csvdesktop.png[200,200]
+
+. Double-click the audit report to view it, then click *Ok* on the *Text Import* dialog:
++
+image:images/audit-textimportok.png[400,400]
+
+. Take a look at your CSV report:
++
+image:images/audit-csvoutput.png[500,500]
+
+== 6.5: Resetting the Lab System (Optional)
+
+. If you want to restart the lab from scratch, run the following as *root* on *audit.example.com*:
++
+----
+[root@audit ~]# rm /etc/audit/rules.d/*
+[root@audit ~]# cp /usr/share/doc/audit/rules/10-base-config.rules /etc/audit/rules.d
+[root@audit ~]# augenrules --load
+[root@audit ~]# cp /etc/default/grub.bak /etc/default/grub
+[root@audit ~]# grub2-mkconfig -o `find /boot -name grub.cfg`
+----
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab7_AIDE.adoc[ Lab 7: AIDE ]
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab7_AIDE.adoc[Lab 7: AIDE^]
+
+

--- a/2020Labs/RHELSecurity/documentation/lab6_Audit.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab6_Audit.adoc
@@ -483,48 +483,6 @@ The CSV output is particularly interesting as it can be imported into
 LibreOffice or any other spreadsheet program that accepts files in the
 Comma Separated Values (CSV) format.
 
-. As *root*, transform today's audit log into the CSV format suitable for use within LibreOffice:
-+
-----
-[root@audit ~]# ausearch --start today --format csv --extra-labels --extra-obj2 > /tmp/audit.log.csv
-----
-
-=== 6.4.5: Viewing the CSV Output Audit Log from the Workstation Bastion Host
-
-In this section, you transfer the CSV file you just created from the *audit.example.com* system to the workstation bastion host system by using `scp`. Then you open the CSV file using LibreOffice from the workstation bastion host.
-
-. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
-+
-----
-[localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
-----
-
-. Use `scp` to transfer the CSV file from the *audit.example.com* system to the desktop of the workstation bastion host system:
-+
-----
-[lab-user@workstation-GUID ~]$ scp root@audit.example.com:/tmp/audit.log.csv ~/Desktop/
-----
-
-. Return to your *Lab Information* web page and click *CONSOLE* for your workstation bastion host:
-+
-image:images/lab1.1-workstationconsole.png[300,300]
-
-. Log in as *lab-user* with *r3dh4t1!* as the password:
-+
-image:images/lab1.1-labuserlogin.png[300,300]
-
-. Locate the CSV file you just copied from the *audit.example.com* system on your workstation bastion host's desktop:
-+
-image:images/audit-csvdesktop.png[200,200]
-
-. Double-click the audit report to view it, then click *Ok* on the *Text Import* dialog:
-+
-image:images/audit-textimportok.png[400,400]
-
-. Take a look at your CSV report:
-+
-image:images/audit-csvoutput.png[500,500]
-
 == 6.5: Resetting the Lab System (Optional)
 
 . If you want to restart the lab from scratch, run the following as *root* on *audit.example.com*:

--- a/2020Labs/RHELSecurity/documentation/lab7_AIDE.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab7_AIDE.adoc
@@ -1,204 +1,255 @@
-== Lab 7: How to use the Advanced Intrusion Detection Environment (AIDE)
+:toc2:
+:linkattrs:
 
-*Lab Length: Medium/Average (~15 mins)*
+= Lab 7: Advanced Intrusion Detection Environment (AIDE)
 
-=== Goal of Lab
-The goal of this lab exercise is to understand how to use the Advanced Intrusion Detection Environment (AIDE).
+.*Lab Length*
+* Medium/Average (~15 mins)
 
-We want to achieve the following objectives in this exercise:
+.*Goal*
+* Understand how to use the Advanced Intrusion Detection Environment (AIDE)
 
-* Install AIDE on your Server A (servera) system
-* Initialize a baseline scan to capture current state
+.*Objectives*
+* Install AIDE on your Server A (*servera*) system
+* Initialize a baseline scan to capture the current state
 * Modify permissions and content on a select file
 * Run a scan to identify drift from the baseline
 * Set audit watches to capture who, when, and how
 
+== 7.1: Introduction
 
-=== Introduction
-AIDE maintains a database that captures the state of critical system configuration files at a point in time, allowing for subsequent analysis to identify drift from a desired state.  AIDE is able to determine what changes were made to a system, but is not able to determine who made the change, when the change occurred, and what command was used to make the change.  For that, we will use auditd and ausearch, which are installed and enabled by default.
+AIDE maintains a database that captures the state of critical system configuration files at a point in time, allowing for subsequent analysis to identify drift from a desired state. AIDE is able to determine what changes were made to a system, but is not able to determine who made the change, when the change occurred, and what command was used to make the change. For that, you use `auditd` and `ausearch`, which are installed and enabled by default.
 
-AIDE and audit watches are complementary security tools that can help you harden your environment.  AIDE allows you to configure files and directories that you want to watch, and audit watches allow you to determine who, when, and how a particular change occurred.  These can be fine tuned over time to include scans of custom files and directories, and watches over files and directories you deem most critical.  More information can be found by reviewing the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using-aide[Red Hat Enterprise Linux Security Guide].
+AIDE and audit watches are complementary security tools that can help you harden your environment. AIDE allows you to configure files and directories that you want to watch, and audit watches allow you to determine the who, when, and how related to a particular change. These can be fine-tuned over time to include scans of custom files and directories as well as watches over the files and directories you deem most critical. More information can be found in the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using-aide[Red Hat Enterprise Linux Security Guide^].
 
-
-=== Lab 7.1 Installing the AIDE package
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+== 7.2: Installing the AIDE package
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *servera.example.com* host as *root*.
+. Log in to the *servera.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@servera.example.com
 ----
-
-
-. AIDE is part of the base repository that comes standard with Red Hat Enterprise Linux, but is not installed by default.  As *root*, install the AIDE package.
-
 +
-[source]
+[NOTE]
+====
+AIDE is part of the base repository that comes standard with Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL), but it is not installed by default.
+====
+
+. As *root*, install the AIDE package:
++
+----
 [root@servera ~]# yum search aide
 [root@servera ~]# yum install aide.x86_64
+----
 
-. After you have installed AIDE, review the configuration file located at:
+. After AIDE is installed, review the configuration file located at:
 +
-[source]
+----
 [root@servera ~]# less /etc/aide.conf
 (Type q to exit less)
-
-. A review of this file will show you the directories and files that are scanned by default and provide a list of what is checked (e.g. permissions, checksums, etc.).  You can also refer to the man page as follows:
+----
 +
-[source]
+A review of this file shows you the directories and files that are scanned by default and provide a list of what is checked (for example, permissions and checksums).
++
+[TIP]
+====
+You can also refer to the man page as follows:
+
+----
 [root@servera ~]# man aide
+----
+====
 
-=== Lab 7.2 Initializing a Baseline Scan
-Organizations often create a locked down standard operating build for provisioning a server.  This includes configuration of the operating system and other software packages.
+== 7.3: Initializing a Baseline Scan
+Organizations often create a locked-down standard operating build for provisioning a server. This includes configuration of the operating system and other software packages.
 
-. After you have provisioned a server, or after you have made configuration changes to an existing server, initiate an AIDE scan as follows:
+. After the server is provisioned, or after you have made configuration changes to an existing server, initiate an AIDE scan as follows:
 +
-[source]
+----
 [root@servera ~]# aide --init
-
-. The previous step does take a few minutes, so you may want to read ahead as you wait.  Upon completion you should see output similar to:
+----
 +
-[source]
+The previous step takes a few minutes, so you may want to read ahead as you wait.
+
+. Look for output similar to the following to see that the process is complete:
++
+----
 Start timestamp: 2019-04-09 20:16:40 -0400 (AIDE 0.16)
 AIDE initialized database at /var/lib/aide/aide.db.new.gz
+----
 
-. To complete the initialization, rename or copy the database file by removing the *new.* from the generated file name as follows:
+. Rename or copy the database file by removing `new.` from the generated filename as shown here, to complete the initialization:
 +
-[source]
+----
 [root@servera ~]# mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
-
-. You now have a baseline scan derived from the rules setup in /etc/aide.conf.  Note that we used the --init parameter (or -i) to initialize the baseline.  In subsequent scans, we will use --check (or -C) to check for changes.  Run a check as follows:
+----
 +
-[source]
+You now have a baseline scan derived from the rules set up in `/etc/aide.conf`. Note that you used the `--init` parameter (or `-i`) to initialize the baseline. In subsequent scans, you use `--check` (or `-C`) to check for changes.
+
+. Run a check:
++
+----
 [root@servera ~]#  aide --check
+----
 
-. This scan should not disclose any deviations from the baseline and return:
+. Examine the output and note that this scan does not disclose any deviations from the baseline:
 +
-[source,text]
+----
 Start timestamp: 2019-04-09 20:21:31 -0400 (AIDE 0.16)
 AIDE found NO differences between database and filesystem. Looks okay!!
+----
 
-=== Lab 7.3 Modifying Permissions and Contents of a File
-. Let’s review the /etc/aide.conf file and look for entries related to ssh.
+== 7.4: Modifying Permissions and Contents of a File
+
+. Review the `/etc/aide.conf` file and look for entries related to SSH:
 +
 ----
 [root@servera ~]# vi /etc/aide.conf
 ----
-Search for line 265 by typing the command *:265*. When you do that, you should see these two lines:
-+
-[source]
-/etc/ssh/sshd_config CONTENT_EX
-/etc/ssh/ssh_config CONTENT_EX
 
-. What this means is that AIDE is monitoring these two files and is looking specifically for changes to content based on sha512 hashes, file type, and access attibutes.  At line 82, you will find the definition for CONTENT_EX:
+. Type the command *:200* to go to line 200 and expect to see these two lines in the results:
 +
-[source]
-[root@servera ~]# vi /etc/aide.conf
+----
+/etc/ssh/sshd_config$ LSPP
+/etc/ssh/ssh_config$ LSPP
+----
++
+This means that AIDE is monitoring these two files and is looking specifically for changes to content based on the `sha256` and `sha512` hashes.
 
+. Find the definition for LSPP, by typing the command *:81* to go to line 81, and expect to see these two lines:
 +
-Search for line 82 by typing the command *:82*. When you do that, you should see these two lines:
-+
-[source]
-# Extended content + file type + access.                                                                                                                                                                                                       
-CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
+----
+# Just do sha256 and sha512 hashes
+LSPP = FIPSR+sha512
+----
 
-. Next we will examine the default rules in the /etc/aide.conf file.  A review of the default rules beginning at line 26 lists the parameters that are included.  For this exercise we will alter the permissions and content of the /etc/ssh/sshd_config file and rerun our scan.
-+
-[source]
-[root@servera ~]# vi /etc/aide.conf
+. Examine the default rules beginning at line 26, by typing *:26*, and note the included parameters.
 
+. Type *:q* to exit vi, and then alter the permissions of the `/etc/ssh/sshd_config` file:
 +
-Search for line 26 by typing *:26*. When you do that you should see the list of the parameters that are included. Type *:q* to exit *vi*, and then type the following commands.
-+
-[source]
+----
 [root@servera ~]# chmod 0644 /etc/ssh/sshd_config
+----
+
+. Open the `/etc/ssh/sshd_config` file for editing so that you can alter its contents:
++
+----
 [root@servera ~]# vi /etc/ssh/sshd_config
+----
 
+. Jump to the end of the file by typing *Shift+G*.
 
-. Using vi again, open the /etc/ssh/sshd_config file and jump to the end by typing *Shift + g*. Then, press the letter *o* to add a line to the end of the file. Append *UseDNS no* to the end of the /etc/ssh/sshd_config file. Then, press *esc* and  save and exit by typing *:wq!*
+. Type the letter *O* to add a line to the end of the file, and append `UseDNS no` to the end of the `/etc/ssh/sshd_config` file.
 
-. When we run AIDE, we expect it to note the change of the permissions and identify a change in the checksum of the file.
-
-. Now let's run a new scan and confirm.
+. Press *esc* and type *:wq!* to save and exit.
 +
-[source]
+When you run AIDE, you expect it to note the change of the permissions and identify a change in the checksum of the file.
+
+. Run a new scan and confirm:
++
+----
 [root@servera ~]# aide --check
+----
 
-. We see that AIDE scanned our files and found two changes.  Your output should look similar to the following:
+. Examine your output, which is similar to the following, and note that AIDE scanned your files and found differences:
 +
-[source]
-[root@servera aide]# aide --check
+----
+[root@servera ~]# aide --check
 Start timestamp: 2019-04-09 20:53:34 -0400 (AIDE 0.16)
 AIDE found differences between database and filesystem!!
+----
 +
-[source]
+----
 Summary:
   Total number of entries:	34527
   Added entries:		0
   Removed entries:		0
   Changed entries:		1
+----
 +
-As you examine the output you will see that permission and content changes were made to the /`/ssh/sshd_config file.
-
-. We can see which permissions specifically changed, which is also the case when other attributes such as user, group, or file type change.  As for content, we can only see that the checksum changes and we would have to recover a previous version of the file to determine the exact content change.  What we can’t tell is the userid who made this change, or what time and how that change was made.
-
-. For that we would need to set audit watches.
-
-. Revert the changes you made in this exercise before proceeding to the next exercise by setting the permissions of sshd_config back to *0600* and removing *UseDNS no* from the end of the file.
+Permission and content changes were made to the `/ssh/sshd_config` file.
 +
-[source]
+You can see which permissions were specifically changed. You can also see changes to other attributes such as user, group, or file type.
+As for content, you can see only that the checksum changes. You need to recover a previous version of the file to determine the exact content change. What you cannot tell is the identity of the user who made this change, or what time and how that change was made. For that, you must set audit watches.
+
+. To revert the changes you made in this section, which is necessary before proceeding to the next exercise, begin by resetting the permissions of `/etc/sshd_config` back to `0600`:
++
+----
 [root@servera ~]# chmod 0600 /etc/ssh/sshd_config
+----
+
+. Open the file for editing so that you can remove the `UseDNS no` from the end of the file:
++
+----
 [root@servera ~]# vi /etc/ssh/sshd_config
-+
+----
 
-. Using vi, jump to the end of the /etc/ssh/sshd_config file by typing *Shift + g*. Then, delete the last time that we added previously by pressing *dd* on the last line, __UseDNS no__. Then, save and exit by pressing *:wq!*
+. In vi, jump to the end of the `/etc/ssh/sshd_config` file by typing *Shift+G*.
 
-. Run *aide --check* again to verify that you have reverted back correctly.  It will show a change in the timestamps (mtime, ctime, etc.), but not to the content.
+. Delete the last line that you added previously by pressing `dd` on the last line, `__UseDNS no__`.
+
+. Press *:wq!* to save and exit.
+
+. Verify that you reverted your changes correctly:
 +
-[source]
+----
 [root@servera ~]# aide --check
+----
 +
-If you want to eliminate the changes resulting from alteration of the timestamps for next part of the lab, you can re-baseline by running steps 1 through 3 in Section 7.2.
-
-===  Lab 7.4 Setting Audit Watches
-. The auditd daemon is installed and enabled by default in Red Hat Enterprise Linux.  Log files reside at /var/log/audit/audit.log based on the configuration in /etc/audit/auditd.conf and the watches in /etc/audit/rules.d/audit.rules.  Audit watches can be set dynamically for the duration of the runtime, or permanently by adding a file to the /etc/audit/rules.d/ directory.
-
-. First, we will enable a dynamic rule at the command line and check a specific file for permissions and attribute changes.  We will do this by using the `auditctl` command.  A full list of watch parameters can be found by reviewing the man page.  For this exercise, let's set a watch and establish a key for the /etc/shadow file as follows:
+Expect to see a change in the timestamps (`mtime`, `ctime`, etc.) but not to the content.
 +
-[source]
+. (Optional) Run steps to eliminate the changes resulting from alteration of the timestamps for the next part of the lab.
+
+== 7.5: Setting Audit Watches
+
+The `auditd` daemon is installed and enabled by default in Red Hat Enterprise Linux. Log files reside at `/var/log/audit/audit.log` based on the configuration in `/etc/audit/auditd.conf` and the watches in `/etc/audit/rules.d/audit.rules`. Audit watches can be set dynamically for the duration of the runtime, or permanently by adding a file to the `/etc/audit/rules.d/` directory.
+
+In this section, you first enable a dynamic rule using the command line and check a specific file for permissions and attribute changes. You do this with the `auditctl` command.
+
+A full list of watch parameters can be found by reviewing the man page.
+
+. Set a watch and establish a key for the `/etc/shadow` file:
++
+----
 [root@servera ~]# auditctl -w /etc/shadow -pa -k shadow_key
-
-* The *-w* indicates that we are watching the /etc/shadow file.
-* The *-pa* parameter indicates permissions and attributes are what we are watching.
-* The *-k* parameter indicates that we have created a key that we can use to search the audit log.
-
-. Let's check for active watches by running the following command:
+----
 +
-[source]
+`-w` indicates that you are watching the `/etc/shadow` file.
++
+`-pa` indicates permissions and attributes are what you are watching.
++
+`-k` indicates that you created a key that you can use to search the audit log.
+
+. Check for active watches:
++
 ----
 [root@servera ~]# auditctl -l
-
 -w /etc/shadow -p a -k shadow_key
 ----
 
-. Now let’s change the permission on the /etc/shadow file, run a scan, and then look for the entry in the audit.log  Before we do that let's re-initialize our database to account for the timestamp change in the sshd_conf file from the previous step.  You should see output similar to the following:
+. Reinitialize the database to account for the timestamp change in the `/etc/sshd_conf` file from the previous step:
 +
 ----
 [root@servera ~]# aide --init
-
 [root@servera ~]# mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
-
 [root@servera ~]# aide --check
+----
 
+. Change the permission on the `/etc/shadow` file and run a scan:
++
+----
 [root@servera ~] chmod 0666 /etc/shadow
-
 [root@servera ~]# aide --check
+----
+
+. Look for the entry in the audit log in your output that is similar to this:
++
+----
 Start timestamp: 2019-04-09 21:20:27 -0400 (AIDE 0.16)
 AIDE found differences between database and filesystem!!
 
@@ -244,12 +295,16 @@ The attributes of the (uncompressed) database(s):
 
 End timestamp: 2019-04-09 21:20:39 -0400 (run time: 0m 12s)
 ----
-. We can clearly see that the permissions on the /etc/shadow file changed, and because we set an audit watch on this file, we can now search for the key in audit log by using the ausearch command that comes with auditd.  Run the following command using the key you created above:
 +
-[source]
-[root@servera ~]$ ausearch -i -k shadow_key
+Note in the output that the permissions on the `/etc/shadow file` changed. Because you set an audit watch on this file, you can now search for the key in the audit log by using the `ausearch` command that comes with `auditd`.
 
-. This command returns the following entry in the audit.log:
+. Search for the `shadow_key` key that you created above:
++
+----
+[root@servera ~]$ ausearch -i -k shadow_key
+----
++
+. Examine the entry returned in the `audit.log`:
 +
 ----
 type=CONFIG_CHANGE msg=audit(04/09/2019 21:18:44.578:127) :  auid=root ses=1 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 op=add_rule key=shadow_key list=exit res=yes
@@ -258,31 +313,46 @@ type=PATH msg=audit(04/09/2019 21:20:22.554:128) : item=0 name=/etc/shadow inode
 type=CWD msg=audit(04/09/2019 21:20:22.554:128) : cwd=/var/lib/aide
 type=SYSCALL msg=audit(04/09/2019 21:20:22.554:128) : arch=x86_64 syscall=fchmodat success=yes exit=0 a0=0xffffff9c a1=0x55a68921f670 a2=0644 a3=0xfff items=1 ppid=1656 pid=2685 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=1 comm=chmod exe=/usr/bin/chmod subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=shadow_key
 ----
-. While there are many attributes in the log entry, five are of particular interest and have been highlighted:
 
-* msg-audit - timestamp
-* name - object acted upon
-* auid - login id of the user who made the change (student)
-* uid - login id of the user who ran the command (root)
-* key - the search key that we setup earlier
-
-. If we decide we want to keep this watch, we need to make it permanent.  We do this by placing a watch in the /etc/audit/rules.d/audit.rules file.  You insert the command in the file as you typed it on the command line, but you remove the the term auditctl.
-
-. Place the following in the /etc/audit/rules.d/audit.rules file:
+. While there are many attributes in the log entry, find the five that are of particular interest:
 +
-[source]
-----
--w /etc/shadow -pa -k shadow_key
+`msg-audit` is the timestamp.
++
+`name` is the object acted upon.
++
+`auid` is the login ID of the user who made the change (student).
++
+`uid` is the login ID of the user who ran the command (root).
++
+`key` is the search key that you set up earlier.
 
+== 7.6: Making the Watch Permanent
+
+If you decide you want to keep this watch, you must make it permanent. You do this by placing a watch in the `/etc/audit/rules.d/audit.rules` file. You insert the command in the file as you typed it on the command line, but you remove the term `auditctl`.
+
+. Open the file `/etc/audit/rules.d/audit.rules` for editing:
++
+----
 [root@servera ~]$ vi /etc/audit/rules.d/audit.rules
 ----
-. In vi, move down a line and type the letter *o* to begin a new line below the cursor and insert the text above. Press *esc* and then save and exit by pressing *:wq!*.
 
-. When the service restarts you can run auditctl -l to verify that your rule has survived.  Note that your auditd is configured to manual start and stop, so you will have to reboot the server to see this change.  If you want to configure a watch, but do not want to reboot your server, create a dynamic rule as we have in this exercise, and then update the audit.rules file for when your server reboots.
-
-. If you want to reboot your server to verify that your rule has survived, do the following with the understanding that a server reboot in the lab environment can take some time:
+. In vi, move down a line and type the letter *o* to begin a new line below the cursor and insert the following text:
 +
-[source]
+----
+-w /etc/shadow -pa -k shadow_key
+----
+
+. Press *Esc*, and then save and exit by pressing *:wq!*.
+
+. When the service restarts, run `auditctl -l` to verify that your rule has survived.
++
+[NOTE]
+====
+Your `auditd` is configured to manually start and stop, so you must reboot the server to see this change. If you want to configure a watch, but do not want to reboot your server, create a dynamic rule as you have in this lab, and then update the `audit.rules` file so that the rule becomes permanent.
+====
+
+. If you want to reboot your server to verify that your rule has survived, run the following:
++
 ----
 [root@servera ~]$ reboot
 [lab-user@workstation-GUID ~]$ ssh root@servera.example.com
@@ -290,7 +360,12 @@ type=SYSCALL msg=audit(04/09/2019 21:20:22.554:128) : arch=x86_64 syscall=fchmod
 -w /etc/shadow -pa -k shadow_key
 ----
 
+[WARNING]
+====
+A server reboot in the lab environment can take some time.
+====
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab8_IdM.adoc[ Lab 8: Identity Management ]
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab8_IdM.adoc[Lab 8: Identity Management^]
+

--- a/2020Labs/RHELSecurity/documentation/lab7_AIDE.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab7_AIDE.adoc
@@ -112,20 +112,20 @@ AIDE found NO differences between database and filesystem. Looks okay!!
 [root@servera ~]# vi /etc/aide.conf
 ----
 
-. Type the command *:200* to go to line 200 and expect to see these two lines in the results:
+. Type the command *:265* to go to line 265 and expect to see these two lines in the results:
 +
 ----
-/etc/ssh/sshd_config$ LSPP
-/etc/ssh/ssh_config$ LSPP
+/etc/ssh/sshd_config CONTENT_EX
+/etc/ssh/ssh_config CONTENT_EX
 ----
 +
-This means that AIDE is monitoring these two files and is looking specifically for changes to content based on the `sha256` and `sha512` hashes.
+This means that AIDE is monitoring these two files and is looking specifically for changes to content based on the `sha512` hash, file type and access attributes.
 
-. Find the definition for LSPP, by typing the command *:81* to go to line 81, and expect to see these two lines:
+. Find the definition for LSPP, by typing the command *:82* to go to line 82, and expect to see these two lines:
 +
 ----
-# Just do sha256 and sha512 hashes
-LSPP = FIPSR+sha512
+# Extended content + file type + access.
+CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 ----
 
 . Examine the default rules beginning at line 26, by typing *:26*, and note the included parameters.

--- a/2020Labs/RHELSecurity/documentation/lab8_IdM.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab8_IdM.adoc
@@ -1,380 +1,455 @@
-= Lab 8: How to create a single sign-on environment for all of your linux servers using Red Hat Identity Management
+:toc2:
+:linkattrs:
 
-*Lab Length: Medium/Average(~15-20 mins)*
+= Lab 8: Single-Sign-on Environment Creation for Linux Servers Using Identity Management in Red Hat Enterprise Linux
 
-== Goal of Lab
-In this exercise you are going to configure clients to attach to a Red Hat Identity Management (IdM) server.  The goal is to create a single-sign-on environment for all of your Linux servers to manage users, hosts, and sudo commands from a central console.  This exercise will already have an IdM server installed, and will focus on registering and managing clients.  The objectives for this exercise are:
+.*Lab Length*
+* Medium/Average (~15-20 mins)
 
+.*Goal*
+* Create a single-sign-on (SSO) environment for all of your Linux^(R)^ servers to manage users, hosts, and sudo commands from a central console
+
+.*Objectives*
 * Install the IdM client on your client systems
 * Configure the client to be part of the IdM realm
-* Create users on the idm server and demonstrate single-sign-on
+* Create users on the IdM server and exercise SSO
 * Create user groups and assign users to those groups
 * Create host groups and assign hosts to those groups
 * Create sudo command groups that allow escalated privileges
-* Integrate user, host and sudo command groups into a policy
+* Integrate user, host, and sudo command groups into a policy
 
-We will be doing this lab exercise using the consoles for both your IdM server and clients. You will access the consoles and your lab environment's power control from the Lab GUID information UI page.
+== 8.1: Introduction
 
-== Introduction
-The IdM server is a 389 based server that has been configured to manage users, hosts, and sudo commands.  It is kerberos based and can operate as a standalone directory server, or can integrate with any LDAP compliant directory servers (e.g. Microsoft Active Directory).  IdM can also be configured to manage DNS for you Linux environment and provide for dynamic DNS updates.   Because the lab already provides DNS we will not have that enabled.  It will also be configured to create user home directories upon first login.
+In this lab, you configure clients to attach to an Identity Management in Red Hat^(R)^ Enterprise Linux (IdM) server. This lab environment already has an IdM server installed, and the lab focuses on registering and managing clients.
 
-== Lab 8.1 Attaching the Clients to the IdM Realm
-. Navigate to the *Lab information page* from the *Lab 0 Setup steps*. This page has your environment's power control and consoles. Click on the console for *IdM1*.
+You use the consoles for both your IdM server and clients. You access the consoles and your lab environment's power control from the Lab GUID information UI page.
+
+The IdM server is a 389-based server that is configured to manage users, hosts, and sudo commands. It is Kerberos-based and can operate as a standalone directory server or integrate with any LDAP-compliant directory servers such as Microsoft Active Directory. IdM can also be configured to manage DNS for your Linux environment and provide for dynamic DNS updates. Because the lab already provides DNS, you do not need dynamic DNS updates enabled.
+
+The IdM server is also configured to create user home directories upon first login.
+
+== 8.2: Attaching the Clients to the IdM Realm
+
+=== 8.2.1: Accessing the IdM Web Interface
+
+. Navigate to the *Lab information page* from the *Lab 0: Setup Steps* and click the console link for *IdM1*:
 +
 image:images/idm-console.png[300,300]
++
+This page has your environment's power control and consoles.
++
+Note that the *IdM1* system was installed with a GUI and already has an IdM server installed on it.
 
-. Notice that the *IdM1* system has been installed with a GUI.
-*IdM1* already has an IdM server installed on it.
-Login with username *admin* and *r3dh4t1!* as the password. If you are required to update the expired admin password in the web UI, just keep the password the same (*r3dh4t1!*). 
+. Log in with the *admin* username and *r3dh4t1!* as the password. If you are required to update the expired admin password in the web UI, just keep the password the same (*r3dh4t1!*). 
+
 +
 image:images/idm-login.png[400,400]
 
-. Navigate to the Firefox web browser (which is under  *Applications*). Open up the Firefox web browser and navigate to *https://idm1.example.com*. This is the UI for the IdM server. Login as *admin* with *r3dh4t1!* as the password. Take a quick glance around. We will revisit this IdM server GUI later in this exercise.
+. Open the Firefox web browser (under *Applications*) and navigate to link:https://idm1.example.com[https://idm1.example.com^]:
 +
 image:images/idm-initiallogin.png[500,500]
++
+This is the UI for the IdM server.
 
-. Next, we are going to attach our client servers to the IdM realm.  The servers we are going to attach are:
+. Log in as *admin* with *r3dh4t1!* as the password, and examine the interface.
++
+You revisit this IdM server GUI later in this exercise.
 
-* idm2.example.com
-* idm3.example.com
+=== 8.2.2: Attaching Client Servers to IdM Realm
 
-. The ipa-client package has already been installed for your convenience.  Next we are going to log into idm2 and idm3 and configure the client.
+In this section, you attach the *idm2.example.com* and *idm3.example.com* client servers to the IdM realm. (The `ipa-client` package is already installed for your convenience.) Then you log in to *idm2* and *idm3* and configure the clients.
 
-. Navigate to the Lab GUID information UI page again. This page has your environment's power control and consoles. Click on the consoles for *IdM2* and *IdM3*.
+. Navigate to the lab GUID information UI page again and click the console links for *IdM2* and *IdM3*:
 +
 image:images/idm2-console.png[200,200]
 image:images/idm3-console.png[200,200]
 
-. Log into *IdM2* as *root* with *r3dh4t1!* as the password.
+. Log in to *IdM2* as *root* with *r3dh4t1!* as the password.
 
-. Now, let's install the IdM client and configure the client to be part of the IdM realm.
-
-. In the console window for *IdM2*, type the following:
+. In the console window for *IdM2*, install the IdM client and configure the client to be part of the IdM realm:
 +
-[source]
 ----
 [root@idm2 ~]# ipa-client-install --mkhomedir --no-ntp
 ----
-. NOTE:
-* mkhomedir - this allows you to create a user home directory upon first login
-* no-ntp - our lab is using chronyd to synchronize time
-* In a production environment, you may want to mount home directories remotely so that there are no user accounts or home directories on your servers.
++
+`--mkhomedir` causes a user home directory to be created upon first login.
++
+`--no-ntp` indicates that the lab is using `chronyd` to synchronize time.
 
-. You will be asked a series of questions during the installation and configuration of your IdM client. Here are the answers to these questions:
++
+[TIP]
+====
+In a production environment, you may want to mount home directories remotely so that there are no user accounts or home directories on your servers.
+====
 
+. Enter the following responses for the installation and configuration of your IdM client:
 * Provide the domain name of your IPA server: *example.com*
 * Provide your IPA server name: *idm1.example.com*
 * Proceed with fixed values and no DNS discovery? *yes*
 * Continue to configure the system with these values? *yes*
 * User authorized to enroll computers: *admin*
-* Password for admin@EXAMPLE.COM: *r3dh4t1!*
+* Password for *admin@EXAMPLE.COM*: *r3dh4t1!*
 +
-NOTE: Had we been using IdM with embedded DNS, it would have auto discovered and input all parameters and simply asked us to confirm.
+[NOTE]
+====
+If using IdM with embedded DNS, all of the parameters and input are auto-discovered and simply require confirmation.
+====
 
-. Repeat the above steps 6-9 for *IdM3*. The *root* password for *IdM3* is also *r3dh4t1!*.
+. Repeat the previous steps to install and configure the IdM client on *IdM3*, logging in as *root* with *r3dh4t1!* as the password.
 
-. Your systems are now configured and enrolled in the IdM realm.  Let's verify enrollment of our 2 client systems.
+=== 8.2.3: Verifying Enrollment of Client Systems
 
-. Navigate back to *IdM1*. If you need to log back in, the password for the Administrator is *r3dh4t1!*. If your Firefox web browser was closed, open up the Firefox web browser and navigate to *https://idm1.example.com* (if you're not already there).
+Your systems are now configured and enrolled in the IdM realm. In this section, you verify enrollment of the two client systems.
 
-. Navigate to the *Identity* -> *Hosts* tab. Notice that both of our client systems, *idm2.example.com* and *idm3.example.com* are showing as Enrolled (in addition to our IdM server, *idm1.example.com*).
+. Navigate back to *IdM1*.
++
+If you need to log in again, the password for the administrator is *r3dh4t1!*.
 
+. If your Firefox web browser is closed, open it again and, if you are not already there, navigate to link:https://idm1.example.com[https://idm1.example.com^].
+
+. Navigate to the *Identity* -> *Hosts* tab.
++
+Note that both of your client systems, *idm2.example.com* and *idm3.example.com* (in addition to the IdM server, *idm1.example.com*) display as *Enrolled*:
++
 image:images/idm-01-hosts.png[700,700]
 
+== 8.3: Configuring a Simple User
 
+In this section, you create a user and exercise SSO.
 
-== Lab 8.2 Configuring a Simple User
-In this exercise we will create a user and demonstrate single-sign-on.
+.  Navigate back to the *IdM1* console.
++
+If you need to log in again, the password for the administrator is *r3dh4t1!*.
 
-.  Navigate back to the *IdM1* console. If you need to log back in, the password for the Administrator is *r3dh4t1!*. Open up the Firefox web browser and navigate to *https://idm1.example.com* (if you're not already there).
+. Open the Firefox web browser and navigate to link:https://idm1.example.com[https://idm1.example.com^] (if you are not already there).
 
-. Navigate to the *Identity* -> *Users* tab. Click on the *Add* button at the far right.
+. Navigate to the *Identity* -> *Users* tab and click *+Add*:
 +
 image:images/idm-02-user1.png[500,500]
 
-. Fill in the form with the following information:
+. Complete the form with the following information:
 
-* User login - *user1*
-* User first name - *User*
-* User last name - *One*
-* New password - *password* (initial password that will have to be changed on first logon)
-* Verify password - *password*
-
-* You do not need to fill in the other items on this form (Class, GID, etc)
-
+* *User login*: *user1*
+* *First name*: *User*
+* *Last name*: *One*
+* *New Password*: *password* (initial password that must be changed on first logon)
+* *Verify Password*: *password*
 +
 image:images/idm-03-user1.png[500,500]
++
+You do not need to fill in the other items on this form (such as *Class* and *GID*).
 
-. When you are done filling out the form, Press *Add*.
-
+. When you finish completing the form, click *Add*:
++
 image:images/idm-04-user1.png[500,500]
 
-
-. Navigate to the *Policy* -> *Host-Based-Access-Control* -> *HBAC Rules* tab.
+. Navigate to the *Policy* -> *Host-Based-Access Control* -> *HBAC Rules* tab:
 +
 image:images/idm-host-based-access-control.png[700,700]
-
 +
-NOTE: Notice the default *allow_all* policy, which allows access to all users and all hosts. This is something that we will delete shortly, but is good for testing for now.
+[NOTE]
+====
+The default *allow_all* policy allows access to all users and all hosts. This is something that you delete shortly, but is useful for testing for now.
+====
 
-. Navigate back to the console for *IdM2* (idm2.example.com). If you are still logged in as *root*, type *exit*. Now, login as follows:
-* username: user1
-* password: password
+. Navigate back to the console for *IdM2* (*idm2.example.com*), and if you are still logged in as *root*, type *exit*, and then log in as *user1* with the *password* password.
 
-. You will be prompted to change your initial password. Feel free to change your initial password to any new password that you can easily remember.
+. When prompted, change your initial password to any new password that you can easily remember.
++
+A home directory is automatically created for *user1*.
 
-* A home directory will be automatically be created for user1.
-
-. From the command line, verify that this local *user1* account does not exist in /etc/passwd. This is because IdM caches credentials locally in the sssd.
-[source]
+. From the command line, verify that this local *user1* account does not exist in `/etc/passwd`:
++
+----
 [user1@idm2 ~]$ grep user1 /etc/passwd
 [user1@idm2 ~]$ exit
+----
++
+This is because IdM caches credentials locally in the System Security Services Daemon (SSSD).
 
+== 8.4: Controlling User-Based Access
 
+In this section, you allow and then restrict access to hosts by specific users.
 
+.  Navigate back to the *IdM1* console.
++
+If you need to log in again, the password for the administrator is *r3dh4t1!*.
 
-== Lab 8.3 User Based Access Control
-In this exercise, we are going to allow/restrict access to hosts by user.
+. Open the Firefox web browser and, if not already there, navigate to link:https://idm1.example.com[https://idm1.example.com^].
 
-.  Navigate back to the *IdM1* console. If you need to log back in, the password for the Administrator is *r3dh4t1!*. Open up the Firefox web browser and navigate to *https://idm1.example.com* (if you're not already there).
+. Navigate to the *Policy* -> *Host-Based-Access-Control* -> *HBAC Rules* tab.
 
-. Navigate to the *Policy* -> *Host-Based-Access-Control* -> *HBAC Rules* tab
-. Click on the box next to the *allow_all* HBAC rule and press *Disable* at the far right. Press *Ok*.
+. For the HBAC rule name, select *allow_all* and click *Disable* on the right, then click *Ok*:
 +
 image:images/idm-05-policy.png[700,700]
-
-. The kerberos ticket you are currently holding may continue to allow/disallow access to a resource after you make a change to a resource on the IdM server.
-As a result, let's go ahead and clear cache for IdM2 and IdM3.
-
-. While there are ways to configure the cache for your specific needs, a quick way to clear the sssd cache is as the root user.  After clearing the cache, you will no longer be able to login. Do these steps on *IdM2* as the *root* user. Log back into *IdM2* as *root*. The password for the *root* user is *r3dh4t1!*.
 +
-[source]
+The Kerberos ticket that you are currently holding may continue to allow and disallow access to a resource after you make a change to a resource on the IdM server. As a result, you must clear the cache for *IdM2* and *IdM3*.
++
+While there are ways to configure the cache for your specific needs, a quick way to clear the SSSD cache is as the *root* user. After clearing the cache, you can no longer log in.
+
+. Stop the SSSD service, clear the cache, and restart the service on *IdM2* as the *root* user--logging back in to *IdM2* as *root* if necessary (using the password *r3dh4t1!*):
++
+----
 [root@idm2 ~]$ systemctl stop sssd.service
 [root@idm2 ~]$ sss_cache -E
 [root@idm2 ~]$ systemctl start sssd.service
+----
 
-. Clear the cache for *IdM3* as well by repeating the step above on *IdM3*.
+. Clear the cache for *IdM3* as well by repeating the previous step on *IdM3*.
 
-. Press the *Add* button at the far right to create a new rule that allows you access to a specific server. For the rule name, type any name of your choice (For example, *my_hbac_rule*).
+. On the right, click *+Add* to create a new rule that allows you access to a specific server, using any name you want for the rule--for example, *my_hbac_rule*.
 
-. Select the *Add and Edit* button to create and edit your rule.
-
+. Click *Add and Edit* to create and edit your rule:
 +
 image:images/idm-06-policy.png[700,700]
 
-. Under *Who*, click on the *+Add* button on the far right in the *Users* section. Press *Add*.
+. Under *Who*, click *+Add* on the far right in the *Users* section, then click *Add*:
 +
 image:images/idm-whoadd.png[700,700]
 
-. Click on the box next to *user1* and add them to the policy by clicking on the *>* button to move user1 from the *Available Users* section to the *Prospective Users* section.
-
+. Select *user1* and click the *>* button to move *user1* from the *Available Users* section to the *Prospective Users* section to add the user to the policy:
 +
 image:images/idm-07-policy.png[700,700]
 
-. Under *Accessing*, select the *+Add* button at the far right.
+. Under *Accessing*, click *+Add* at the far right:
 +
 image:images/idm-accessingadd.png[700,700]
 
-. Click on the box next to *idm2.example.com* and add it to the policy by clicking on the *>* button to move idm2.example.com from the *Available Hosts* section to the *Prospective Hosts* section. Press *Add*.
-
+. Select *idm2.example.com* and click the *>* button to move *idm2.example.com* from the *Available Hosts* section to the *Prospective Hosts* section, then click *Add* to add it to the policy:
 +
 image:images/idm-08-policy.png[700,700]
 
-. Under *Via Service*, select the *+Add* button at the far right.
+. Under *Via Service*, click *+Add* at the far right:
 +
 image:images/idm-viaservice.png[700,700]
 
-. Click on the box next to both *login* and *sshd* and add them to the policy by clicking on the *>* button to move them from the *Available HBAC Services* section to the *Prospective HBAC Services* section. Press *Add*.
+. Select *login* and *sshd* and click the *>* button to move them from the *Available HBAC Services* section to the *Prospective HBAC Services* section, then click *Add* to add them to the policy:
 
 +
 image:images/idm-09-policy.png[700,700]
 
-. Now, let's try logging into the *IdM2* server as *user1* with the password that you set previously. You should be able to successfully login as *user1* on *IdM2* since our policy that we just created above allows both login and ssh for user1 on idm2.example.com.
+. Attempt to log in to the *IdM2* server as *user1* with the password that you set previously.
++
+Expect to be able to successfully log in as *user1* on *IdM2* because the policy that you just created allows both login and SSH for *user1* on *idm2.example.com*.
 
-. Now, let's try logging into the *IdM3* server as *user1* with the password that you set previously. You should be restricted from logging into *IdM3* with a *Permission denied* error since this server is not in the policy that we created previously.
+. Attempt to log in to the *IdM3* server as *user1* with the password that you set previously.
++
+Expect to be restricted from logging in to *IdM3* with a *Permission denied* error because this server is not in the policy that you created previously.
 
-. Clear the cache on the server where you successfully logged in (IdM2). Log into *IdM2* from the console as *root* with password *r3dh4t1!* and execute the following commands below to clear the cache.
-[source]
+. Log in to *IdM2* from the console as *root* with password *r3dh4t1!*, and execute the following commands to clear the cache:
++
+----
 [root@idm2 ~]$ systemctl stop sssd.service
 [root@idm2 ~]$ sss_cache -E
 [root@idm2 ~]$ systemctl start sssd.service
+----
 
-. Now let's disable the policy to ready the system for the next exercise. Navigate to the *Policy* -> *Host-Based Access Control* -> *HBAC Rules* tab and click on the box next to the policy you created previously. Then, click on *Disable* on the far right.
+.  Navigate to the *Policy* -> *Host-Based Access Control* -> *HBAC Rules* tab, select *my_hbac_rule* and click *Disable* on the far right to disable the policy:
 +
-image:images/idm-disablepolicy.png[700,700]
+image:images/idm-disablepolicy.png[700,700]+
++
+The system is ready for the next section.
 
-== (Optional) Lab 8.4 User Group Based Access Control
-In this exercise we are going to restrict access to hosts by user group.
+== 8.5: (Optional) Controlling User Group-Based Access
 
-.  Navigate back to the *IdM1* console. If you need to log back in, the password for the Administrator is *r3dh4t1!*. Open up the Firefox web browser and navigate to *https://idm1.example.com* (if you're not already there).
+In this section, you restrict access to hosts by user group.
 
-. Navigate to the *Identity* -> *Groups* tab. Select *User Groups* under Group Categories on the left panel and add a group by pressing the *+Add* button.
+. Navigate back to the *IdM1* console.
++
+If you need to log in again, the password for the administrator is *r3dh4t1!*.
+
+. Open the Firefox web browser and, if you are not already there, navigate to link:https://idm1.example.com[https://idm1.example.com^].
+
+. Navigate to the *Identity* -> *Groups* tab, select *User Groups* on the left under *Group categories*, and click *+Add* to add a group:
 +
 image:images/idm-usergroups.png[700,700]
 
-. Provide a User Group name (For example, *my_user_group*) and press  the *Add and Edit* button.
+. Provide a user group name (for example, *my_user_group*), then click *Add and Edit*:
 +
 image:images/idm-10-group.png[700,700]
 
-. Add a user to your user group by pressing the *+Add* button.
+. Click *+Add* to add a user to your user group:
 +
 image:images/idm-add.png[700,700]
 
-. Click on the box next to *user1* and add it to your user group by clicking on the *>* button to move it from the *Available User login* section to the *Prospective User login* section. Press *Add*.
+. Select *user1* and click the *>* button to move it from the *Available User login* section to the *Prospective User login* section, then click *Add* it to your user group:
 +
 image:images/idm-11-group.png[700,700]
 
-. Navigate to the *Identity* -> *Groups* -> *Host Groups* tab. Click on the *+Add* button at the far right.
+. Navigate to the *Identity* -> *Groups* -> *Host Groups* tab and click *+Add*:
 +
 image:images/idm-hostgroups.png[700,700]
 
-. Enter a *Host-group* name (For example, my_host_group ) and Click on the *Add and Edit button*.
+. Enter a host group name (for example, *my_host_group*) and click *Add and Edit button*:
 +
 image:images/idm-12-group.png[700,700]
-. Then, press *+Add* on the Host Group page.
+
+. Click *+Add* on the *Host Group* page:
 +
 image:images/idm-add-my-hostgroup.png[700,700]
 
-. Click on the box next to *idm3.example.com* and add this host into your host group by clicking on the *>* button to move it from the *Available Host name* section to the *Prospective Host name* section. Press *Add*.
+. Select *idm3.example.com* and click the *>* button to move it from the *Available Host name* section to the *Prospective Host name* section, then click *Add* to add this host into your host group:
 +
 image:images/idm-13-group.png[700,700]
 
-. Navigate to the *Policy -> Host-Based-Access-Control -> HBAC Rules* tab. Press the *+Add* button at the far right.
+. Navigate to the *Policy -> Host-Based-Access-Control -> HBAC Rules* tab and click *+Add*:
 +
 image:images/idm-host-based-access-control-add.png[700,700]
 
-. Give the new HBAC Rule a name (For example, name it *my_group_hbac* ). Press *Add and Edit*.
+. Give the new HBAC rule a name (for example, *my_group_hbac*), then click *Add and Edit*:
 
 +
 image:images/idm-14-hbac.png[700,700]
 
-. Under the *Who* section, select your user group. Press *+Add*. Then, move your user group from the *Available User Groups* section into the *Prospective User Groups* section. Press *Add*.
+. Under the *Who* section, select your user group, click *+Add*, then move your user group from the *Available User Groups* section into the *Prospective User Groups* section and click *Add*:
 +
 image:images/idm-usergroup-add.png[700,700]
 image:images/idm-add-user-groups-into-hbac.png[700,700]
 
-. Under the *Accessing* section, select your host group. Press *+Add*. Then, move your host group from the *Available Host Groups* section to the *Prospective Host Groups* section. Press *Add*.
+. Under the *Accessing* section, select your host group, click *+Add*, then move your host group from the *Available Host Groups* section to the *Prospective Host Groups* section and click *Add*:
 +
 image:images/idm-accessing-hostgroup.png[700,700]
 image:images/idm-add-hostgroup-hbac.png[700,700]
 
-. Under the *Via Service* section, press *+Add* next to *Services*. Then, select *login* and *sshd* under *Available HBAC Services* and move that to *Prospective HBAC Services*.
+. Under the *Via Service* section, click *+Add* next to *Services*, then select *login* and *sshd* under *Available HBAC Services* and move them to *Prospective HBAC Services*:
 +
 image:images/idm-viaservice-add.png[700,700]
 image:images/idm-addservice-hbac.png[700,700]
 
-. Now, go back to your console for *IdM3* and login as *user1* with the password that you set. You should be able to logon to this server since it is specified in the your group HBAC policy that we created in this exercise.
+. Return to the *IdM3* console and log in as *user1* with the password that you set.
++
+Expect to be able to log in to this server because it is specified in the your group HBAC policy that you created in this section.
 
-. Navigate to your console for *IdM2* and login as *user1* with the password that you set. You should be restricted from logging into *IdM2* with a Permission denied error since *IdM2* is not in your group HBAC policy that we created in this exercise.
+. Navigate to your *IdM2* console and login as *user1* with the password that you set.
++
+Expect to be restricted from logging in to *IdM2* with a *Permission Denied* error because *IdM2* is not in your group HBAC policy that you created in this exercise.
 
-. Now, let's clear the cache on the server where you successfully logged in (IdM3). Log into *IdM3* from the console as *root* with password *r3dh4t1!* and execute the following commands below to clear the cache.
-[source]
+. Return to the *IdM3* console where you successfully logged in, log into *IdM3* as *root* using *r3dh4t1!* as the password, and execute the commands below to clear the cache:
++
+----
 [root@idm3 ~]$ systemctl stop sssd.service
 [root@idm3 ~]$ sss_cache -E
 [root@idm3 ~]$ systemctl start sssd.service
+----
 
+. Do not disable the policy because you are going to add to it in the next step.
 
-. Do not disable the policy because we are going to add to it in the next step
+== 8.6: (Optional) Creating `sudo` Command Groups
 
-Grouping users and hosts allows you to move users into and out of groups, thereby, inheriting and disinheriting access.  The real strength with this method comes in the next exercise where we create sudo command groups.  Rather than creating service accounts with shared passwords for a group of administrators, you can do the following:
+Grouping users and hosts allows you to move users into and out of groups, thereby inheriting and disinheriting access. In this section, where you create sudo command groups, you witness the clear advantage of using this method.
+
+Rather than creating service accounts with shared passwords for a group of administrators, you can do the following:
 
 * Add a user to a user group
-* That user will inherit access to a specific group of hosts
-* That user will also inherit escalated privileges required to perform their role on those hosts
-* That user’s activity will be logged centrally
+* That user inherits access to a specific group of hosts
+* That user also inherits escalated privileges required to perform their role on those hosts
+* That user’s activity is logged centrally
 
-== (Optional) Lab 8.5 Creating sudo Command Groups
-This exercise will build off the previous exercise by adding a sudo command group to the existing policy.  Therefore, in addition to having access to specific hosts, the users in the group will also be granted escalated privileges.  To simplify the demonstration, we will create a sudo command group with one command in it: the ability to execute yum.
+This section expands on the previous section by adding a sudo command group to the existing policy.  Therefore, in addition to having access to specific hosts, the users in the group are also granted escalated privileges. To simplify the lab, you create a sudo command group with one command in it--the ability to execute `yum`.
 
-. Before creating this to the policy, log into a server that your user (user1) has access to (*IdM3*) from the previous step to verify that you do not have access to escalate and run yum. Use the password that you set earlier for this user.
+. Before adding this to the policy, log in to a server that your user (*user1*) has access to (*IdM3*) from the previous step to verify that you do not have access to escalate and run `yum`:
 +
-[source]
+----
 [user1@idm3 ~]# sudo yum update
+----
++
+Use the password that you set earlier for this user.
 
-. Even though you type in the password that you set for *user1*, you will get a *Sorry, try again* error. After three attempts,  you will be prevented from trying further.
+. Even though you type in the password that you set for *user1*, you get a *Sorry, try again* error. After three attempts, you are prevented from trying further.
 
-.  Navigate back to the *IdM1* console. If you need to log back in, the password for the Administrator is *r3dh4t1!*. Open up the Firefox web browser and navigate to *https://idm1.example.com* (if you're not already there).
+.  Navigate back to the *IdM1* console.
++
+If you need to log in again, the password for the administrator is *r3dh4t1!*.
 
-. Navigate to *Policy -> Sudo* tab. Select *Sudo Commands*.
+. Open the Firefox web browser and navigate to link:https://idm1.example.com[https://idm1.example.com^].
+
+. Navigate to the *Policy -> Sudo* tab and select *Sudo Commands*:
 +
 image:images/idm-sudo-commands.png[700,700]
 
-. Click on *+Add* at the far right to add a command.
+. On the far right, click *+Add* to add a command:
 +
 image:images/idm-sudo-add.png[700,700]
 
-. For the Sudo Command, enter */usr/bin/yum*. Press *Add and Edit*.
+. For the sudo command, enter */usr/bin/yum*, then click *Add and Edit*:
 +
 image:images/idm-15-sudo.png[700,700]
 
-. Select *Sudo Command Groups* from the *Sudo* drop down. Press the *+Add* button at the far right to create a group.
+. From the *Sudo* menu, select *Sudo Command Groups* and click *+Add* at the far right to create a group:
 +
 image:images/idm-sudo-command-group.png[700,700]
 
-. Create a new group by providing a Sudo Command Group Name (For example, my_sudo_group). Press *Add and Edit*.
+. Create a new group by providing a *Sudo Command Group* name (for example, *my_sudo_group*), then click *Add and Edit*:
 +
 image:images/idm-16-sudo.png[700,700]
 
-. Press the *+Add* button.  Add the /usr/bin/yum command from the previous step from the *Available Sudo Command* section to the *Prospective Sudo Command* section. Press *Add*.
+. Click *+Add* and add the `/usr/bin/yum` command from the previous step from the *Available Sudo Command* section to the *Prospective Sudo Command* section, then click *Add*:
 +
 image:images/idm-17-sudo.png[700,700]
 
-. Select *Sudo Rules* from the *Sudo* drop down. Then, click on the *+Add* button on the far right to create a new rule.
+. Select *Sudo Rules* from the *Sudo* menu, then click *+Add* on the right to create a new rule:
 +
 image:images/idm-add-sudo-rules.png[700,700]
 
-. Provide a Sudo Rule Name (For example, my_sudo_rule). Press the *Add and Edit* button.
+. Enter a sudo *Rule name* (for example, *my_sudo_rule*), then click *Add and Edit*:
 +
 image:images/idm-18-sudo.png[700,700]
 
-. In the *Who* section, add your user group under *User Groups*. Press *+Add*.
+. In the *Who* section, add your user group under *User Groups*, then click *+Add*:
 +
 image:images/idm-whoadd2.png[1000,1000]
 
-. Next, select *my_user_group* from the list of *Available User Groups* and add it to the *Prospective User Groups* by pressing the > button. Press *Add*.
+. From the list of *Available User Groups*, select *my_user_group* and click the *>* button to add it to the *Prospective User Groups*, then click *Add*:
 +
 image:images/idm-addmyusergroup.png[500,500]
 
-. Add your host group under *Access this host -> Host Groups*. Press *+Add*.
+. Add your host group under *Access this host -> Host Groups*, then click *+Add*:
 +
 image:images/idm-add-host-group.png[700,700]
 image:images/idm-add-to-my-host-group.png[700,700]
 
-. In the *Run Commands* section, add your sudo group under *Sudo Allow Command Groups*. Press *+Add*.
+. In the *Run Commands* section, add your sudo group (*my_sudo_group* in this example) under *Sudo Allow Command Groups* and then click *+Add*:
 +
 image:images/idm-sudo-command.png[700,700]
 image:images/idm-add-sudo-commands.png[700,700]
 
-. Navigate to *Policy -> Host Based Access Control -> HBAC Rules*.
+. Navigate to *Policy -> Host Based Access Control -> HBAC Rules*:
 +
 image:images/idm-hbac.png[300,300]
 
-. Click on the rule you created earlier (*my_group_hbac*).
+. Click the *my_group_hbac* rule that you created earlier:
 
-. Navigate to *Via Service*. Click on *+Add* in the *Services* section. Next, select *sudo* from the list of *Available* HBAC Services and add it to the *Prospective HBAC Services* by pressing the > button. Now, you should see sudo as a service in addition to logon and sshd.
+. Navigate to *Via Service* and click *+Add* in the *Services* section.
+
+. From the list of *Available* *HBAC Services*, select *sudo* and click the *>* button to add it to *Prospective* *HBAC Services*:
 +
 image:images/idm-viaservice-add.png[800,800]
 image:images/idm-19-sudo.png[700,700]
-
-. Make sure you are logged out as user1 on *IdM3* and log back in as root and clear the cache.  The kerberos ticket held by user1 may may not be updated with the change to the rules we just made.
-
 +
-[source]
+Expect to see *sudo* as a service in addition to *logon* and *SSHD*.
+
+. Make sure that you are logged out as *user1* on *IdM3*, then log in again as *root* and clear the cache:
++
+----
 [root@idm2 ~]$ systemctl stop sssd.service
 [root@idm2 ~]$ sss_cache -E
 [root@idm2 ~]$ systemctl start sssd.service
-
-
-. Log back into the server that your user (user1) has access to (*IdM3*) from the previous step to verify that you do have access to escalate and run yum. Use the password that you set earlier for this user.
+----
 +
-[source]
+The Kerberos ticket held by *user1* may not be updated with the change to the rules that you just made.
+
+. Using the password for this user that you set earlier, log in again to the server that your user (*user1*) has access to (*IdM3*), and verify that you have access to escalate, by running `yum`:
++
+----
 [user1@idm3 ~]# sudo yum update
-
+----
 +
-NOTE:
-You could have simplified this by adding a user and a command rather than a user group and command group. However, what we want to show is how you can group users, hosts, and sudo commands into one policy, which allows you to add and remove users that will inherit and dis-inherit access respectively.
-
+[NOTE]
+====
+You can simplify this by adding a user and a command rather than a user group and command group. However, this lab attempts to illustrate how you can group users, hosts, and sudo commands into one policy, which allows you to add and remove users that inherit and disinherit access, respectively.
+====
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab9_GPG.adoc[ Lab 9: GNU Privacy Guard ]
+link:README.adoc#table-of-contents[ Table of Contents^] | link:lab9_GPG.adoc[Lab 9: GNU Privacy Guard^]
+

--- a/2020Labs/RHELSecurity/documentation/lab9_GPG.adoc
+++ b/2020Labs/RHELSecurity/documentation/lab9_GPG.adoc
@@ -1,98 +1,130 @@
-== Lab 9: GNU Privacy Guard (GPG)
+:toc2:
+:linkattrs:
 
-*Lab Length: Short (~10 mins)*
+= Lab 9: GNU Privacy Guard (GPG)
 
-=== Goal of Lab
-The goal of this lab exercise is to introduce you to GNU Privacy Guard (GPG), which can be used to identify yourself and encrypt your communications.
+.*Lab Length*
+* Short (~10 mins)
 
-There are various tools that you can use to manage GPG on your system, graphical as well as command line.  We will use the command line tools for the steps in this exercise.
+.*Goal*
+* Become familiar with GNU Privacy Guard (GPG), which can be used to identify yourself and encrypt your communications.
 
-This exercise will demonstrate a simple use case in which you encrypt personal documents.  You can build on what you have learned by using your key to sign documents, encrypt email communications. sign RPM packages, or simply share documents with a colleague.
+* There are various tools you can use to manage GPG on your system--graphical as well as command line. You use the command line tools for the steps in this lab.
 
-=== Introduction
-All Red Hat Enterprise Linux packages are signed with the Red Hat GPG key. GPG stands for GNU Privacy Guard, or GnuPG, a free software package used for ensuring the authenticity of distributed files. For example, a private key (secret key) locks the package while the public key unlocks and verifies the package. If the public key distributed by Red Hat Enterprise Linux does not match the private key during RPM verification, the package may have been altered and therefore cannot be trusted.
+* This lab demonstrates a simple use case where you encrypt personal documents. You can build on what you have learned by using your GPG key to sign documents, encrypt email communications, sign RPM packages, or simply share documents with a colleague.
 
-GNU Privacy Guard (GPG) is a cryptographic software package that is included in your Red Hat Enterprise Linux subscription.  GPG is used to identify yourself and encrypt and authenticate your communications, including those with people you do not know. GPG allows anyone reading a GPG-signed email to verify its authenticity. In other words, GPG allows someone to be reasonably certain that communications signed by you actually are from you. GPG is useful because it helps prevent third parties from altering code or intercepting conversations and altering the message.
+== 9.1: Introduction
 
-GPG can also be used to encrypt files at rest, which will be the focus of this lab exercise.
+All Red Hat^(R)^ Enterprise Linux^(R)^ (RHEL) packages are signed with the Red Hat GPG key. GPG is also known as GnuPG, a free software package used for verifying the authenticity of distributed files. For example, a private key (secret key) locks the package while the public key unlocks and verifies the package. If the public key distributed by Red Hat Enterprise Linux does not match the private key during RPM verification, the package may have been altered and therefore cannot be trusted.
 
-This lab exercise will allow you to become comfortable with some the basics of GPG, after which point, you can delve further into the documentation to use more advanced features. These include signing RPM packages, encrypting email communications, and more.
+GPG is a cryptographic software package that is included in your Red Hat Enterprise Linux subscription. GPG is used to identify yourself and to encrypt and authenticate your communications, including those with people you do not know. GPG allows anyone reading a GPG-signed email to verify its authenticity. In other words, GPG allows the recipient to be reasonably certain that communications signed by you are actually from you. GPG is useful because it helps prevent third parties from altering code or intercepting conversations and altering messages.
 
-More information can be found on the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-encryption#sec-Creating_GPG_Keys[Red Hat Enterprise Linux 7 Security Guide] and on the https://gnupg.org/index.html[GNU Privacy Guard webpage].
+GPG can also be used to encrypt files at rest, which is the focus of this lab.
 
+This lab allows you to become comfortable with some the basics of GPG, after which you can delve further into the documentation to use more advanced features. These include signing RPM packages, encrypting email communications, and more.
 
-=== Lab 9.1 Generating a New Key Pair
-Once you have created a new key pair, you can export these keys to identify yourself to the rest of the world, or simply use it locally to encrypt your files at rest.
+More information can be found on the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-encryption#sec-Creating_GPG_Keys[Red Hat Enterprise Linux 7 Security Guide^] and on the link:https://gnupg.org/index.html[GNU Privacy Guard webpage^].
 
-. If not already there, log into to the workstation bastion host as *lab-user* from your desktop system *replacing GUID with your lab's GUID*. Use the password *r3dh4t1!*
+== 9.2: Generating a New Key Pair
+
+In this section, you generate a new GPG key pair. After you create a new key pair, you can export this keys to identify yourself to the rest of the world, or simply use it locally to encrypt your files at rest.
+
+. If you are not already there, log in to the workstation bastion host as *lab-user* from your desktop system (replacing `GUID` with your lab-provided GUID and using *r3dh4t1!* as the password):
 +
-[source]
 ----
 [localhost ~]$ ssh lab-user@workstation-GUID.rhpds.opentlc.com
 ----
 
-. Log into the *servera.example.com* host as *root*.
+. Log in to the *servera.example.com* host as *root*:
 +
-[source]
 ----
 [lab-user@workstation-GUID ~]$ ssh root@servera.example.com
 ----
 
-. Now let's generate your new key pair as *root* on *servera.example.com*.
+. Generate your new key pair as *root* on *servera.example.com*:
++
+----
+[root@servera ~]# gpg2 --full-generate-key
+----
 
-	[root@servera ~]# gpg2 --full-generate-key
+. When asked, enter or provide this information:
+* *Key Type*: *(1)* to select the default, RSA is the default
+* *Key Size*: *2048*
+* *Expiration*: *0* for no expiration, this is generally fine for local encryption
+* *Real Name*: *labuser*, but this can be anything
+* *Email address*: *labuser@test.com*, but this can be any email address
+* *Comment*, press *Enter* to leave the comment empty
+* *Okay/Quit*: *(O)*
+* *Passphrase*: A sufficiently difficult passphrase that can protect against attack and that you can remember
++
+After providing these details, your system starts generating the key pair.
 
-. You will be asked to provide the following information:
+. When asked, move your mouse or type random keystrokes to assist in generating entropy.
++
+Eventually, the process completes and the new key pair is ready for you to use. The output lists your key and your fingerprint.
 
-* Key Type - RSA is the default. Type *(1)* to pick this.
-* Key Size - Type *2048*.
-* Expiration - Type *0* for no expiration. This is generally fine for local encryption
-* Real Name: Type *labuser*. This can be anything.
-* Email address: labuser@test.com. This can be any email address.
-* For *Comment*, just press enter to have a blank comment.
-*  Type (O) for Okay/Quit.
-* Passphrase: Type anything you want and can remember. Make this hard enough to protect against attacks.
+. Run these commands, which may be useful at a later time when you want to view your keys and fingerprints:
++
+----
+[root@servera ~]# gpg2 --list-keys
+[root@servera ~]# gpg2 --fingerprint
+----
++
+The contents of your key is stored in your home directory in the file `.gnupg`. Even if someone were to compromise your computer, this would be of no use to them as long as your passphrase is sufficiently hard to crack. That said, always maintain a backup.
 
+== 9.3: Encrypting Documents
+In this section, you encrypt and decrypt a document for private use. You begin by creating a document with sensitive information.
 
-. At this point you system will start generating the key pair.  You will be asked to assist in helping generate entropy by moving your mouse or typing random keystrokes.  Eventually it will complete and you will have your new key pair that you can now use.  The output will list your key and your fingerprint.  If you wish to view them at a later time, run the following commands:
+. Type the following to create a document with sensitive information:
++
+----
+[root@servera ~]# echo “I love Red Hat” > sensitive.txt
+----
 
-	[root@servera ~]# gpg2 --list-keys
-	[root@servera ~]# gpg2 --fingerprint
+. Verify that you can read the document in its unencrypted format:
++
+----
+[root@servera ~]# cat sensitive.txt
+----
 
-The contents of your key is stored in your home directory at .gnupg.  Even if someone were to compromise your computer, this would be of no use to them as long as your passphrase is sufficiently hard to crack.  That said, always maintain a backup.
+. Encrypt the file by typing the following command and, when asked, enter the user ID you used when creating your key, followed by a carriage return to complete the task:
++
+----
+[root@servera ~]# gpg2 -e sensitive.txt
+----
++
+You now have a new file entitled `sensitive.txt.gpg`. The `.gpg` extension indicates that it is a file that was encrypted with a GPG key.
 
-=== Lab 9.2 Encrypting Documents
-In this step we will show you how to encrypt and un-encrypt a document for private use.  We will start by creating a document with sensitive information.
+. Verify the encryption:
++
+----
+[root@servera ~]# cat sensitive.txt.gpg
+----
+Note that the output is encrypted and cannot be read.
 
-. Please type the following:
+. Invoke the following command, which prompts you for the passphrase you created earlier to read the file:
++
+----
+[root@servera ~]# gpg2 -d sensitive.txt.gpg
+----
 
-	[root@servera ~]# echo “I love Red Hat” > sensitive.txt
-
-. To verify that you can read the document in it’s un-encrypted format, type the following:
-
-	[root@servera ~]# cat sensitive.txt
-
-. Now we can encrypt the file by typing the following command. You will be asked to enter the User ID you used when creating your key, followed by a carriage return to complete the task.
-
-	[root@servera ~]# gpg2 -e sensitive.txt
-
-. You now have a new file entitled sensitive.txt.gpg.  The .gpg extension indicates that it is a file that has been encrypted with a GPG key.  Verify the encryption by typing the following:
-
-	[root@servera ~]# cat sensitive.txt.gpg
-
-. You will see that the output is encrypted and cannot be read.  You can read this file by typing the following command, which will prompt you for the passphrase you created earlier:
-
-	[root@servera ~]# gpg2 -d sensitive.txt.gpg
-
-. Next, we will delete the original file and then recreate it in its un-encrypted format from the encrypted file:
-
-	[root@servera ~]# rm sensitive.txt
-	[root@servera ~]# gpg2 sensitive.txt.gpg
-	[root@servera ~]# ls -l sensitive*
-
-. You now have a new copy of your original file.  Also, note that during an active session, you may not be asked to provide a passphrase within a period of time.  You can modify the duration of the cache.  View the GPG documentation at the link provided earlier for more information.
+. Delete the original file and then recreate it in its unencrypted format from the encrypted file:
++
+----
+[root@servera ~]# rm sensitive.txt
+[root@servera ~]# gpg2 sensitive.txt.gpg
+[root@servera ~]# ls -l sensitive*
+----
++
+You now have a new copy of your original file.
++
+[NOTE]
+====
+During an active session, you may not be asked to provide a passphrase within a period of time. You can modify the duration of the cache. View the GPG documentation at the link provided earlier for more information.
+====
 
 
 <<top>>
 
-link:README.adoc#table-of-contents[ Table of Contents ] | link:lab10_firewalld.adoc[ Lab 10: Firewalld ]
+link:README.adoc#table-of-contents[Table of Contents^] | link:lab10_firewalld.adoc[Lab 10: Firewalld^]
+


### PR DESCRIPTION
No need for the OpenSCAP change from here: ba19fe8a7147e46b743cd397b715cdcb34e37089 since it was already fixed by the tech-writer.

Othen than that I looked through each of the recent updates on 2020Labs RHEL Security doc and incorporated into the new documentation.