### PR TITLE
Removing a $ from the first command line block that was still there

### DIFF
--- a/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
+++ b/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
@@ -13,7 +13,7 @@ Almost all software you are running in your containers does not require root. Yo
 +
 [source]
 ----
-[localhost ~]$ oc new-project myproject
+oc new-project myproject
 ----
 
 . In the OpenShift console, navigate to *Home->Projects*, search for *myproject* and click on it.


### PR DESCRIPTION
Signed-off-by: Pedro Ibáñez <ptrnull@gmail.com>
Removing a $ from the first command line block that was still there, to avoid issues when the user copy&paste the commands.