### PR TITLE
New PR for Lab 1 and Lab 2

### DIFF
--- a/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
+++ b/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
@@ -6,7 +6,7 @@ The goal of this lab is to learn about the default security technologies in Red 
 
 === Introduction
 
-Almost all software you are running in your containers does not require 'root' level access. Your web applications, databases, load balancers, number crunchers, etc. do not need to be run as root ever. Building container images that do not require root at all and basing images off of non-privileged container images are needed for container security. However, the vast majority of container images in the world today, such as the community container images available on Docker Hub, require root. By default, no containers are allowed to run as root in Red Hat OpenShift Container Platform. An admin can override this, otherwise all user containers run without ever being root. This is particularly important in multi-tenant OpenShift Kubernetes clusters, where a single cluster may be serving multiple applications and multiple development teams. It is not always practical or even advisable for administrators to run separate clusters for each.
+Almost all software you are running in your containers does not require 'root' level access. Your web applications, databases, load balancers, number crunchers, etc. do not need to be run as 'root' ever. Building container images that do not require 'root' at all and basing images off of non-privileged container images are needed for container security. However, the vast majority of container images in the world today, such as the community container images available on Docker Hub, require 'root' user. By default, no containers are allowed to run as 'root' on Red Hat OpenShift Container Platform. An admin can override this, otherwise all user containers run without ever becoming 'root'. This is particularly important in multi-tenant OpenShift Kubernetes clusters, where a single cluster may be serving multiple applications and multiple development teams. It is not always practical or even advisable for administrators to run separate clusters for each.
 
 === Lab 1.1 Pull 'rogue' container image from Docker Hub and observe how OpenShift locks down the container by default
 
@@ -172,7 +172,7 @@ AH00558: httpd: Could not reliably determine the server's fully qualified domain
 
 . So we have learned that by adding SCC privileges to a Service Account and using that Service Account to run a pod that requires elevated privileges, we can get it to run securely on OpenShift. Please keep in mind that *best practice is to assign minimal SCC privileges* that are required for pod security to such service accounts. 
 
-Per OpenShift Documentation (https://docs.openshift.com/container-platform/4.10/security/container_security/security-hosts-vms.html) the best practice is: most containers, except those managing or monitoring the host system itself, should run as a non-root user. Dropping the privilege level or creating containers with the least amount of privileges possible is recommended best practice for protecting your own OpenShift Container Platform clusters.  
+Per OpenShift Documentation (https://docs.openshift.com/container-platform/4.10/security/container_security/security-hosts-vms.html) the best practice is for most containers, except those managing or monitoring the host system itself, to run as a non-root user. Dropping the privilege level or creating containers with the *least amount of privileges possible* is recommended best practice for protecting your own OpenShift Container Platform clusters.  
 
 <<top>>
 

--- a/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
+++ b/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
@@ -76,6 +76,11 @@ image:images/lab1.1-describepod-error.png[]
 +
 Notice that the output shows that the container failed after trying to start on port 80 and terminated due to a CrashLoopBackOff error. Also notice the default OpenShift Security Context Constraints (SCC) policy that is in place is 'restricted' (openshift.io/scc: restricted).
 
+. Finally, investigate your pod yaml in the OpenShift console by navigating to the *YAML** view of your pod in the OpenShift console. Scroll down to the containers definition and notice how the SCC has dropped several capabilites and added a specifc runAsUser. These modifications have prevented your pod from scheduling because it was originally designed in an insecure state.
++
+image:images/lab1.1-scc-modify.png[]
+
+
 === Lab 1.2 Work around the default container security restriction by using service accounts with SCC privileges
 
 . Now let's fix this issue. In order to allow containers to run with elevated SCC privileges, we will create a Service Account (a special user account to run services) called 'privileged-sa':
@@ -169,10 +174,6 @@ AH00558: httpd: Could not reliably determine the server's fully qualified domain
 
 Per OpenShift Documentation (https://docs.openshift.com/container-platform/4.10/security/container_security/security-hosts-vms.html) the best practice is: most containers, except those managing or monitoring the host system itself, should run as a non-root user. Dropping the privilege level or creating containers with the least amount of privileges possible is recommended best practice for protecting your own OpenShift Container Platform clusters.  
 
-. Finally, investigate your pod yaml in the OpenShift console by navigating to the *YAML** view of your pod in the OpenShift console. Scroll down to the containers definition and notice how the SCC has dropped several capabilites and added a specifc runAsUser. These modifications have prevented your pod from scheduling because it was originally designed in an insecure state.
-+
-image:images/lab1.1-scc-modify.png[]
-+
 <<top>>
 
 link:README.adoc#table-of-contents[ Table of Contents ]

--- a/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
+++ b/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
@@ -28,19 +28,17 @@ image:images/lab1.1-myproject.png[]
 image:images/lab1.1-4.7.33-workloads.png[]
 
 
-NOTE: It may be easier to use *Developer* perspective of OpenShift console to navigate to a project and click "+Add" button on the left hand side menu  to initiate that workflow. 
+  NOTE: It may be easier to use *Developer* perspective of OpenShift console to navigate to a project and click "+Add" button on the left hand side menu  to initiate that workflow.
+  
 . Then, click on *Container Images* . Make sure that *Image name from external registry* is selected and for the Image Name, type *docker.io/httpd*. Press the magnifying glass.
-
 +
 image:images/lab1.1-4.7.33-image-external.png[]
-+
 
-NOTE: Notice that this container image requires to be run as 'root' and listen on port 80.
-
-
+  NOTE: Notice that this container image requires to be run as 'root' and listen on port 80.
+  
 . Leave other values as defaults and press *Create*.
 
-. Now, go back to your terminal and go into the project you just created by typing *oc project myproject*. Then, take a look at your pods by typing *oc get pods*. Notice that one of your pods has a CrashLoopBackOff error.
+. Now, go back to your terminal and navigate into the project you just created by typing *oc project myproject*. Then, take a look at your pods by typing *oc get pods*. Notice that one of your pods has a CrashLoopBackOff error.
 +
 image:images/lab1.1-crashloopbackofferror.png[]
 
@@ -55,13 +53,15 @@ POD=`oc get pods --selector app=httpd -o custom-columns=NAME:.metadata.name --no
 ----
 
 . Notice that you get permission denied errors saying that you cannot bind to port 80. This is because the proccess was not startup as root and was modified by the security context constraint to run as a specific user. 
+
 +
 image:images/lab1.1-noport80.png[1500,1500]
 
 . Also we can review failing container logs via OpenShift UI console, Log tab for that pod:
 +
 image:images/lab1.1-failingpod-log.png[]
-+
+
+
 . For a more detailed look, type 'oc describe pod ....' with the name of your pod.
 
 +
@@ -73,8 +73,8 @@ oc describe pod $pod
 ----
 +
 image:images/lab1.1-describepod-error.png[]
-+
-Notice that the output shows that the container failed after trying to start on port 80 and terminated due to a CrashLoopBackOff error. Also notice the default OpenShift Security Context Constraints (SCC) policy that is in place is 'restricted' (openshift.io/scc: restricted).
+
+. Notice that the output shows that the container failed after trying to start on port 80 and terminated due to a CrashLoopBackOff error. Also notice the default OpenShift Security Context Constraints (SCC) policy that is in place is 'restricted' (openshift.io/scc: restricted).
 
 . Finally, investigate your pod yaml in the OpenShift console by navigating to the *YAML** view of your pod in the OpenShift console. Scroll down to the containers definition and notice how the SCC has dropped several capabilites and added a specifc runAsUser. These modifications have prevented your pod from scheduling because it was originally designed in an insecure state.
 +
@@ -83,7 +83,7 @@ image:images/lab1.1-scc-modify.png[]
 
 === Lab 1.2 Work around the default container security restriction by using service accounts with SCC privileges
 
-. Now let's fix this issue. In order to allow containers to run with elevated SCC privileges, we will create a Service Account (a special user account to run services) called 'privileged-sa':
+. Now let's resolve this issue. In order to allow containers to run with elevated SCC privileges, we will create a Service Account (a special user account to run services) called 'privileged-sa':
 +
 [source]
 ----

--- a/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
+++ b/2021Labs/OpenShiftSecurity/documentation/lab1.adoc
@@ -2,7 +2,7 @@
 
 
 === Goal of Lab 1
-The goal of this lab is to learn about the default security technologies in Red Hat OpenShift Container Platform. Specifically, you will see how OpenShift blocks 'rogue' containers with images from from Docker Hub from running as a privileged root user and how you can work around that restrictions for this specific container.
+The goal of this Lab is to learn about the default security technologies in Red Hat OpenShift Container Platform. Specifically, you will see how OpenShift blocks 'rogue' containers with images from from Docker Hub from running as a privileged root user and how you can work around that restrictions for this specific container.
 
 === Introduction
 
@@ -158,7 +158,7 @@ Events:
   Normal  ScalingReplicaSet  2m41s  deployment-controller  Scaled down replica set httpd-6b8f7b7c98 to 0
 ----
 
-. We now see that Replica Set that controls pods instances has been regenerated and our HTTP server pod is running OK which we can check in its logs:
+. We now see that Replica Set that controls pods instances has been regenerated and our HTTP server pod is running OK which we can also check in its logs:
 +
 [source]
 ----
@@ -170,7 +170,9 @@ AH00558: httpd: Could not reliably determine the server's fully qualified domain
 ...
 ----
 
-. So we have learned that by adding SCC privileges to a Service Account and using that Service Account to run a pod that requires elevated privileges, we can get it to run securely on OpenShift. Please keep in mind that *best practice is to assign minimal SCC privileges* that are required for pod security to such service accounts. 
+=== Summary
+
+So you have learned that OpenShift by default blocks containers that need to run with elevated privileges. Also, by adding SCC privileges to a Service Account and using that Service Account to run a pod that requires elevated privileges, you can get it to run securely on OpenShift. Please keep in mind that best approach is to always assign minimal SCC privileges that are required for pod security to such service accounts. 
 
 Per OpenShift Documentation (https://docs.openshift.com/container-platform/4.10/security/container_security/security-hosts-vms.html) the best practice is for most containers, except those managing or monitoring the host system itself, to run as a non-root user. Dropping the privilege level or creating containers with the *least amount of privileges possible* is recommended best practice for protecting your own OpenShift Container Platform clusters.  
 

--- a/2021Labs/OpenShiftSecurity/documentation/lab2.adoc
+++ b/2021Labs/OpenShiftSecurity/documentation/lab2.adoc
@@ -6,12 +6,12 @@ The goal of this lab is to learn about how to implement network isolation betwee
 
 === Introduction
 
-[Kubernetes](https://kubernetes.io/docs/concepts/services-networking/network-policies/ "Network Policies") are an easy way for Project Administrators to define exactly what ingress/egress traffic is allowed to any pod, from any other pod, including traffic from pods located in other projects. By default, all Pods in a project are accessible from all other Pods and network endpoints. To isolate one or more Pods in a project, you can create NetworkPolicy objects in that project to indicate the allowed incoming connections. Project administrators can create and delete NetworkPolicy objects within their own project.
+[Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/ ) are an easy way for Project Administrators to define exactly what ingress/egress traffic is allowed to any pod, from any other pod, including traffic from pods located in other projects. By default, all Pods in a project are accessible from all other Pods and network endpoints. To isolate one or more Pods in a project, you can create NetworkPolicy objects in that project to indicate the allowed incoming connections. Project administrators can create and delete NetworkPolicy objects within their own project.
 
 If a Pod is matched by selectors in one or more NetworkPolicy objects, then it will accept only connections that are allowed by at least one of those NetworkPolicy objects. A Pod that is not selected by any NetworkPolicy objects is fully accessible.
 
-==== objective
-The objective of the exercise below is to create multiple projects and to test the communication between them. You will introduce network policies that will block communication across projects.
+=== Objective
+The objective of the exercise below is to create multiple projects and to test application communication between them. You will introduce Network policies that will block application communications across projects and then allow some.
 
 Project-c will have a hello-world application to which you will send requests.
 Projects-a, b and c will all have a client application. The client from project-c will always be able to communication with hello-world in project-c since they are in the same project. However, depending on the network policies in place at times you will be blocked from communicating from clients in projects a and b to the hello-world application in project c.
@@ -65,6 +65,7 @@ This will create a new app, which is a 'hello world' container based on image st
 ----
 oc get pods
 ----
+
 +
 image:images/lab2.1-ocgetpods.png[]
 
@@ -75,7 +76,7 @@ image:images/lab2.1-ocgetpods.png[]
 
 [localhost ~]$ oc run client --image=fedora --command -- tail -f /dev/null
 pod/client created
-
+----
 
 . Let's confirm that our client pod and hello world pod are now running.
 +
@@ -83,6 +84,7 @@ pod/client created
 ----
 oc get pods
 ----
+
 +
 image:images/lab2.1-ocgetpods2.png[]
 
@@ -169,7 +171,7 @@ Now let's take a look at the default Network Policies in the OpenShift web conso
 https://console-openshift-console.apps.cluster-tx8sn.tx8sn.sandbox1590.opentlc.com
 ----
 
-. Log into the web console, then go to Projects and find the project, *proj-c*. Navigate into *proj-c*, then select *Networking* -> *Network Policies*.
+. Log into the OpenShift web console, then go to Projects and find the project, *proj-c*. Navigate into *proj-c*, then select *Networking* -> *Network Policies*.
 
 +
 image:images/lab2.1.10-webconsole2.png[]
@@ -218,13 +220,12 @@ image:images/lab2.2-curlfail.png[]
 Remember to exit the pod with the `exit` command.
 
 
-
-. Same kind of failure you would get if you try to access application running in *proj-c* from *proj-b* because the Network Policy blocks traffic from ALL namespaces
+. Same kind of failure you would get if you try to access application running in *proj-c* from *proj-b* because the *deny-other-namespaces* Network Policy blocks traffic from ALL namespaces
 
 === Lab 2.3 Creating Network Policies for selective network access
 
-. Here you will create additional Network Policy that will allow access to pods running in *proj-c* from those running in different projects, selected by their labels. In the previous lab you created a Network Policy that denies access to all pods in *proj-c* from other projects. 
-. Now, similar to Lab 2.2, let's create a Network Policy that is based on the sample "ALLOW traffic from all Pods in a particular namespace". In the 'podSelector.matchLabels' section specify 'deployment:hello' to select the 'hello' pods and in the 'namespaceSelector.matchLabels' section specify 'name:proj-a' to indicate that you will allow traffic from apps deployed in that namespace (recall that we labeled it with 'name:proj-a'). Press *Create* to create that Network Policy
+. Here you will create additional Network Policy that will allow access to pods running in *proj-c* project from those running in different projects, selected by their labels. In the previous lab you created a Network Policy that denies access to all pods in *proj-c* from other projects. 
+. Now, similar to Lab 2.2, let's create a Network Policy that is based on the sample "ALLOW traffic from all Pods in a particular namespace" policy. In the 'podSelector.matchLabels' section specify 'deployment:hello' to select the 'hello' labeled pods and in the 'namespaceSelector.matchLabels' section specify 'name:proj-a' to indicate that you will allow traffic from apps deployed in that namespace (recall that we labeled it with 'name:proj-a' in Lab 2.1). Press *Create* to create Network Policy
 +
 image:images/lab2.3-allow-traffic-from-proj-a.png[]
 
@@ -232,7 +233,7 @@ image:images/lab2.3-allow-traffic-from-proj-a.png[]
 +
 image:images/lab2.3-policies-list.png[]
 
-. Next, again try to curl the 'hello world' service in project *proj-c* from the client running in *proj-a*. Notice that the curl succeeds this time because ingress traffic is explicitely allowed from *proj-a* to our 'hello world' pod 
+. Next, again try to access the 'hello world' service in project *proj-c* from the Client running in *proj-a*. Notice that the curl succeeds this time because ingress traffic is explicitely allowed from *proj-a* to our 'hello world' pod by the *web-allow-production* Network Policy:
 +
 [source]
 ----
@@ -242,7 +243,7 @@ sh-5.0# curl -v hello.proj-c:8080
 +
 image:images/lab2.3-curl-from-proj-a-ok.png[]
 
-. Next, try to curl the 'hello world' service in project *proj-c* from the client running in *proj-b*. Notice that the curl still fails because the first Network Policy still blocks it and the second one is not applicable to pods in *proj-b*:
+. Next, try to curl the 'hello world' service in project *proj-c* from the Client running in *proj-b*. Notice that the curl fails because the first Network Policy still blocks it and the second one is not applicable to pods running in *proj-b*:
 +
 [source]
 ----
@@ -252,6 +253,9 @@ sh-5.0# curl -v hello.proj-c:8080
 +
 image:images/lab2.3-curl-from-proj-b-fails.png[]
 
+=== Summary
+
+You have learned how to created multiple OpenShift projects/namespaces and test application communication between them. You also learned how to create declarative Network Policies that block application communications across projects and then allow application communications between selected applications running in specific namespaces. Network Policies when used propely are very powerful way to implement cloud native applications network security.
 
 <<top>>
 


### PR DESCRIPTION
I have noticed that after merging my PRs created last week, today, Lab 1 (POD security and SCC): https://github.com/RedHatDemos/SecurityDemos/blob/master/2021Labs/OpenShiftSecurity/documentation/lab1.adoc and especially Lab 2 (Network Policies): https://github.com/RedHatDemos/SecurityDemos/blob/master/2021Labs/OpenShiftSecurity/documentation/lab2.adoc where formatting of source code and image tags is pretty messed up. I have resolved both formatting issues in the 'master' branch my downstream repo and confirm the README docs are rendering OK. Would be great to get corresponding .adoc files above to replace the current versions of those files in the upstream repo.
thanks,
Dan Z 